### PR TITLE
fix(wfm): accept trailing 总图 as a 蓝图 synonym

### DIFF
--- a/src/warframe/services/wfm-service/wfm-service.item-matcher.ts
+++ b/src/warframe/services/wfm-service/wfm-service.item-matcher.ts
@@ -12,6 +12,7 @@ interface WFMItemLookupData {
 export const wfmItemMatcher = (() => {
   const setSuffix = '一套'
   const bpSuffix = '蓝图'
+  const bpAliasSuffix = '总图'
   const bpShortSuffix = '图'
   const primeSuffix = 'prime'
   const warframePartSuffix = ['系统', '头部神经光元', '机体']
@@ -62,8 +63,8 @@ export const wfmItemMatcher = (() => {
 
   function removeNameSuffix(input: string): { pure: string, suffix: string } {
     let hasBPSuffix = false
-    if (input.endsWith(bpSuffix) || input.endsWith(bpShortSuffix)) {
-      input = input.replace(new RegExp(`(?:${bpSuffix}|${bpShortSuffix})$`), '')
+    if (input.endsWith(bpSuffix) || input.endsWith(bpAliasSuffix) || input.endsWith(bpShortSuffix)) {
+      input = input.replace(new RegExp(`(?:${bpSuffix}|${bpAliasSuffix}|${bpShortSuffix})$`), '')
       hasBPSuffix = true
     }
 
@@ -71,8 +72,8 @@ export const wfmItemMatcher = (() => {
       input = input.replace(new RegExp(`${setSuffix}$`), '')
     }
 
-    if (input.endsWith(bpSuffix) || input.endsWith(bpShortSuffix)) {
-      input = input.replace(new RegExp(`(?:${bpSuffix}|${bpShortSuffix})$`), '')
+    if (input.endsWith(bpSuffix) || input.endsWith(bpAliasSuffix) || input.endsWith(bpShortSuffix)) {
+      input = input.replace(new RegExp(`(?:${bpSuffix}|${bpAliasSuffix}|${bpShortSuffix})$`), '')
       hasBPSuffix = true
     }
 

--- a/tests/services/wfm/wm.wfm.matcher.spec.ts
+++ b/tests/services/wfm/wm.wfm.matcher.spec.ts
@@ -17,6 +17,8 @@ describe('wfm-item-matcher helpers', () => {
       { input: 'Rhino Prime 机体', pure: 'rhinoprime', suffix: '机体' },
       { input: 'Volt Prime 系统', pure: 'voltprime', suffix: '系统' },
       { input: 'Volt Prime 蓝图', pure: 'voltprime', suffix: '蓝图' },
+      { input: 'Volt Prime 总图', pure: 'voltprime', suffix: '蓝图' },
+      { input: '夜灵总图', pure: '夜灵', suffix: '蓝图' },
     ]
 
     for (const testCase of cases) {
@@ -37,6 +39,7 @@ describe('wfm-item-matcher helpers', () => {
       { input: '花甲', output: 'wisp' },
       { input: '龙头', output: 'chroma头部神经光元' },
       { input: '奶爸头', output: 'oberon头部神经光元' },
+      { input: '夜灵总图', output: 'revenant蓝图' },
     ]
 
     for (const testCase of cases) {


### PR DESCRIPTION
Allow inputs like 夜灵总图 to resolve the same way as 夜灵蓝图.