### PR TITLE
fix(wfm): omit copyable whispers from wm output

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,11 +12,11 @@ export function setupCommands(ctx: Context, deps: PluginDependencies): void {
   const wfm = createWfmCommands(deps)
   const miscs = createMiscsCommands(deps)
 
-  ctx.command('wm <item-name:text>', '请使用wmi替代').action(wfm.wmCommand)
+  ctx.command('wm <item-name:text>', '查询wm的物品价格（物品名字禁用空格）').action(wfm.wmCommand)
   ctx
     .command('wmr <item-name:text>', '查询wm的紫卡价格')
     .action(wfm.wmrCommand)
-  ctx.command('wmi <item-name:text>', '查询wm的物品价格').action(wfm.wmCommand)
+  ctx.command('wmi <item-name:text>', '查询wm的物品价格（含可复制消息）').action(wfm.wmiCommand)
   ctx.command('wmu', '更新wm缓存数据', { hidden: true }).action(wfm.wmuCommand)
 
   ctx

--- a/src/commands/wfm.ts
+++ b/src/commands/wfm.ts
@@ -17,26 +17,39 @@ import {
 
 export function createWfmCommands(deps: PluginDependencies): {
   wmCommand: (_action: Argv, input: string) => Promise<Element | string>
+  wmiCommand: (_action: Argv, input: string) => Promise<Element | string>
   wmrCommand: (_action: Argv, input: string) => Promise<string>
   wmuCommand: (_action: Argv, _input: string) => Promise<string>
   pmodhistoryCommand: (_action: Argv, _input: string) => Promise<string>
 } {
   const { render } = deps
 
+  async function itemOrdersCommand(
+    _action: Argv,
+    input: string,
+    includeWhispers: boolean,
+  ): Promise<Element | string> {
+    const result = await getItemOrders(input)
+    if (!result.ok) {
+      return t(result)
+    }
+
+    if (!_action.session?.app.puppeteer) {
+      return render(ItemOrderComponent(result.data.item, result.data.orders, result.data.statistics))
+    }
+
+    const component = await generateImageElementOutput(_action.session?.app.puppeteer, ItemOrderComponent(result.data.item, result.data.orders, result.data.statistics))
+
+    return wmMessage(component, result.data.item, result.data.orders, result.data.statistics, includeWhispers)
+  }
+
   return {
     wmCommand: async (_action: Argv, input: string) => {
-      const result = await getItemOrders(input)
-      if (!result.ok) {
-        return t(result)
-      }
+      return itemOrdersCommand(_action, input, false)
+    },
 
-      if (!_action.session?.app.puppeteer) {
-        return render(ItemOrderComponent(result.data.item, result.data.orders, result.data.statistics))
-      }
-
-      const component = await generateImageElementOutput(_action.session?.app.puppeteer, ItemOrderComponent(result.data.item, result.data.orders, result.data.statistics))
-
-      return wmMessage(component, result.data.item, result.data.orders, result.data.statistics)
+    wmiCommand: async (_action: Argv, input: string) => {
+      return itemOrdersCommand(_action, input, true)
     },
 
     wmrCommand: async (_action: Argv, input: string) => {

--- a/src/messages/wfm.tsx
+++ b/src/messages/wfm.tsx
@@ -24,18 +24,23 @@ export function wmMessage(
   img: Element,
   item: ItemShort,
   orders: OrderWithUser[],
-  statistics?: ItemStatisticsSummary,
+  statistics: ItemStatisticsSummary | undefined,
+  includeWhispers: boolean,
 ): Element {
-  const lines = orders.slice(0, 3)
-    .map(order => '\n'
+  const lines = includeWhispers
+    ? orders.slice(0, 3).map(order => '\n'
       + `/w ${order.user?.ingameName ?? 'Unknown'} Hi! I want to buy: "${item.i18n?.en?.name ?? item.i18n?.['zh-hans']?.name ?? item.slug}${!item.maxRank || item.maxRank === 0 ? '' : ` (rank ${order.rank})`}" for ${order.platinum} platinum. (warframe.market)`)
+    : []
   const statLine = statistics ? buildStatisticsTextLine(statistics) : ''
+  const text = `${statLine ? `\n${statLine}\n` : ''}${lines.join('')}`
+  if (!text) {
+    return img
+  }
   return (
     <message>
       {img}
       <div>
-        {statLine ? `\n${statLine}\n` : ''}
-        {lines.join('')}
+        {text}
       </div>
     </message>
   )

--- a/tests/messages/wfm.message.spec.ts
+++ b/tests/messages/wfm.message.spec.ts
@@ -1,0 +1,85 @@
+import type { ItemShort, ItemStatisticsSummary, OrderWithUser } from '../../src/warframe'
+import { expect } from 'chai'
+import { h } from 'koishi'
+import { wmMessage } from '../../src/messages/wfm'
+
+const img = h('img', { src: 'data:image/png;base64,test' })
+
+function item(overrides: {
+  slug?: string
+  maxRank?: number
+  en?: string
+} = {}): ItemShort {
+  return {
+    slug: overrides.slug ?? 'primed_continuity',
+    maxRank: overrides.maxRank,
+    i18n: {
+      en: { name: overrides.en ?? 'Primed Continuity' },
+    },
+  } as unknown as ItemShort
+}
+
+function order(ingameName: string, platinum: number, rank = 0): OrderWithUser {
+  return {
+    user: { ingameName },
+    platinum,
+    rank,
+  } as unknown as OrderWithUser
+}
+
+const statistics: ItemStatisticsSummary = {
+  chart: [],
+  recentAvg: 100,
+  recentVolume: 12,
+  baselineMedian: 95,
+  trend: 'up',
+  onlineMin: 90,
+}
+
+describe('wm messages', () => {
+  it('includes copyable whispers and rank for wmi output', () => {
+    const output = wmMessage(
+      img,
+      item({ maxRank: 10 }),
+      [order('SellerOne', 50, 8), order('SellerTwo', 55, 10)],
+      statistics,
+      true,
+    ).toString()
+
+    expect(output).to.include('/w SellerOne Hi! I want to buy: "Primed Continuity (rank 8)" for 50 platinum. (warframe.market)')
+    expect(output).to.include('/w SellerTwo Hi! I want to buy: "Primed Continuity (rank 10)" for 55 platinum. (warframe.market)')
+    expect(output).to.include('近3天均价 100p')
+  })
+
+  it('omits rank from whispers when the item has no max rank', () => {
+    const output = wmMessage(
+      img,
+      item(),
+      [order('SellerOne', 50)],
+      statistics,
+      true,
+    ).toString()
+
+    expect(output).to.include('/w SellerOne Hi! I want to buy: "Primed Continuity" for 50 platinum. (warframe.market)')
+    expect(output).to.not.include('(rank')
+  })
+
+  it('omits copyable whispers from wm output but keeps statistics', () => {
+    const output = wmMessage(
+      img,
+      item(),
+      [order('SellerOne', 50), order('SellerTwo', 55)],
+      statistics,
+      false,
+    ).toString()
+
+    expect(output).to.not.include('/w')
+    expect(output).to.include('近3天均价 100p')
+    expect(output).to.include('↑7天95p')
+    expect(output).to.include('成交12笔')
+  })
+
+  it('returns the image unchanged when there is no statistics text and no whispers', () => {
+    expect(wmMessage(img, item(), [order('SellerOne', 50)], undefined, false)).to.equal(img)
+  })
+})


### PR DESCRIPTION
Keep the full whisper-inclusive output on wmi so group chats are not flooded.