### PR TITLE
fix(wfm): match omitted relic names and missing prime part suffixes

### DIFF
--- a/src/warframe/services/wfm-service/wfm-service.item-matcher.ts
+++ b/src/warframe/services/wfm-service/wfm-service.item-matcher.ts
@@ -21,20 +21,45 @@ export const wfmItemMatcher = (() => {
   const bpAliasSuffix = '总图'
   const bpShortSuffix = '图'
   const primeSuffix = 'prime'
-  const warframePartSuffix = ['系统', '头部神经光元', '机体']
-  const weaponPartSuffix = [
+  const relicSuffix = '遗物'
+  const relicEnSuffix = 'relic'
+  const neuropticsSuffix = '头部神经光元'
+  const cerebrumSuffix = '头部'
+  const headShortSuffix = '头'
+  const partSuffixes = [
+    neuropticsSuffix,
+    '项圈扣',
+    '项圈带',
+    '连接器',
+    '下弓臂',
+    '上弓臂',
+    '系统',
+    '机体',
+    '外壳',
+    '外甲',
+    '机翼',
+    cerebrumSuffix,
     '枪管',
     '枪托',
     '枪机',
     '弓弦',
-    '上弓臂',
-    '下弓臂',
+    '弓身',
     '刀刃',
+    '爪刃',
     '握柄',
+    '握把',
     '拳套',
     '圆盘',
-    '连接器',
-  ]
+    '镖袋',
+    '护手',
+    '饰物',
+    '锤头',
+    '链条',
+    '星镖',
+    '靴子',
+    '手套',
+  ].sort((left, right) => right.length - left.length)
+  const headSuffixLookup = [neuropticsSuffix, cerebrumSuffix]
   const warframeAliasDict: Record<string, string> = ((aliasObject) => {
     const transformedObject: Record<string, string> = {}
     for (const [key, aliases] of Object.entries(aliasObject)) {
@@ -55,6 +80,14 @@ export const wfmItemMatcher = (() => {
     return transformedObject
   })(warframeAlias)
 
+  function resolvePartSuffixes(suffix: string): string[] {
+    if (suffix === neuropticsSuffix || suffix === cerebrumSuffix || suffix === headShortSuffix) {
+      return headSuffixLookup
+    }
+
+    return suffix ? [suffix] : ['']
+  }
+
   function removeNameSuffix(input: string): { pure: string, suffix: string } {
     let hasBPSuffix = false
     if (input.endsWith(bpSuffix) || input.endsWith(bpAliasSuffix) || input.endsWith(bpShortSuffix)) {
@@ -71,26 +104,24 @@ export const wfmItemMatcher = (() => {
       hasBPSuffix = true
     }
 
-    const suffix
-      = warframePartSuffix.find(value => input.endsWith(value))
-        ?? weaponPartSuffix.find(value => input.endsWith(value))
-        ?? (input.endsWith('头') ? '头部神经光元' : undefined)
-        ?? (hasBPSuffix ? bpSuffix : undefined)
-        ?? ''
-
-    if (suffix) {
-      input = input.endsWith('头') ? input.replace(/头$/, '') : input
-      const pure = input.replace(new RegExp(`${suffix}$`), '')
+    const matchedPartSuffix = partSuffixes.find(value => input.endsWith(value))
+    if (matchedPartSuffix) {
       return {
-        pure,
-        suffix,
+        pure: input.slice(0, input.length - matchedPartSuffix.length),
+        suffix: matchedPartSuffix === cerebrumSuffix ? neuropticsSuffix : matchedPartSuffix,
       }
     }
-    else {
+
+    if (input.endsWith(headShortSuffix)) {
       return {
-        pure: input,
-        suffix,
+        pure: input.slice(0, input.length - headShortSuffix.length),
+        suffix: neuropticsSuffix,
       }
+    }
+
+    return {
+      pure: input,
+      suffix: hasBPSuffix ? bpSuffix : '',
     }
   }
 
@@ -107,57 +138,69 @@ export const wfmItemMatcher = (() => {
     return candidates
   }
 
+  function lookupByNormalizedName(
+    name: string,
+    lookup: Pick<WFMItemLookupData, 'globalItemDict' | 'globalItemNameToSlugDict'>,
+  ): ItemShort | undefined {
+    const slug = lookup.globalItemNameToSlugDict[name]
+    return slug ? lookup.globalItemDict[slug] : undefined
+  }
+
   function shortHandProcess(
     input: string,
     lookup: Pick<WFMItemLookupData, 'globalItemDict' | 'globalItemNameToSlugDict'>,
   ): ItemShort | undefined {
     const { pure: inputNoSuffix, suffix } = removeNameSuffix(input)
     if (inputNoSuffix === input) {
-      const fixSet = input + setSuffix
-      const fixSetRes = lookup.globalItemNameToSlugDict[fixSet]
+      const fixSetRes = lookupByNormalizedName(input + setSuffix, lookup)
       if (fixSetRes)
-        return lookup.globalItemDict[fixSetRes]
+        return fixSetRes
 
       const fixPrimeCandidates = buildPrimeNameCandidates(input)
       for (const fixPrime of fixPrimeCandidates) {
-        const fixPrimeRes = lookup.globalItemNameToSlugDict[fixPrime]
+        const fixPrimeRes = lookupByNormalizedName(fixPrime, lookup)
         if (fixPrimeRes)
-          return lookup.globalItemDict[fixPrimeRes]
+          return fixPrimeRes
 
-        const fixPrimeSet = fixPrime + setSuffix
-        const fixPrimeSetRes = lookup.globalItemNameToSlugDict[fixPrimeSet]
+        const fixPrimeSetRes = lookupByNormalizedName(fixPrime + setSuffix, lookup)
         if (fixPrimeSetRes)
-          return lookup.globalItemDict[fixPrimeSetRes]
+          return fixPrimeSetRes
       }
 
-      const fixBP = input + bpSuffix
-      const fixBPRes = lookup.globalItemNameToSlugDict[fixBP]
+      const fixBPRes = lookupByNormalizedName(input + bpSuffix, lookup)
       if (fixBPRes)
-        return lookup.globalItemDict[fixBPRes]
+        return fixBPRes
 
       for (const fixPrime of fixPrimeCandidates) {
-        const fixPrimeBP = fixPrime + bpSuffix
-        const fixPrimeBPRes = lookup.globalItemNameToSlugDict[fixPrimeBP]
+        const fixPrimeBPRes = lookupByNormalizedName(fixPrime + bpSuffix, lookup)
         if (fixPrimeBPRes)
-          return lookup.globalItemDict[fixPrimeBPRes]
+          return fixPrimeBPRes
       }
+
+      const fixRelicRes = lookupByNormalizedName(input + relicSuffix, lookup)
+      if (fixRelicRes)
+        return fixRelicRes
+
+      const fixRelicEnRes = lookupByNormalizedName(input + relicEnSuffix, lookup)
+      if (fixRelicEnRes)
+        return fixRelicEnRes
     }
     else {
-      const fixBP = inputNoSuffix + suffix + bpSuffix
-      const fixBPRes = lookup.globalItemNameToSlugDict[fixBP]
-      if (fixBPRes)
-        return lookup.globalItemDict[fixBPRes]
-
       const fixPrimeCandidates = buildPrimeNameCandidates(inputNoSuffix)
-      for (const fixPrime of fixPrimeCandidates) {
-        const fixPrimeRes = lookup.globalItemNameToSlugDict[fixPrime + suffix]
-        if (fixPrimeRes)
-          return lookup.globalItemDict[fixPrimeRes]
+      for (const resolvedSuffix of resolvePartSuffixes(suffix)) {
+        const fixBPRes = lookupByNormalizedName(inputNoSuffix + resolvedSuffix + bpSuffix, lookup)
+        if (fixBPRes)
+          return fixBPRes
 
-        const fixPrimeBP = fixPrime + suffix + bpSuffix
-        const fixPrimeBPRes = lookup.globalItemNameToSlugDict[fixPrimeBP]
-        if (fixPrimeBPRes)
-          return lookup.globalItemDict[fixPrimeBPRes]
+        for (const fixPrime of fixPrimeCandidates) {
+          const fixPrimeRes = lookupByNormalizedName(fixPrime + resolvedSuffix, lookup)
+          if (fixPrimeRes)
+            return fixPrimeRes
+
+          const fixPrimeBPRes = lookupByNormalizedName(fixPrime + resolvedSuffix + bpSuffix, lookup)
+          if (fixPrimeBPRes)
+            return fixPrimeBPRes
+        }
       }
     }
   }
@@ -237,19 +280,21 @@ export const wfmItemMatcher = (() => {
     const candidates = new Set<string>()
     const { pure, suffix } = removeNameSuffix(input)
 
-    candidates.add(input)
-    candidates.add(input + bpSuffix)
-    candidates.add(`${input}blueprint`)
-    candidates.add(input + setSuffix)
-    candidates.add(`${input}set`)
-
-    if (suffix) {
-      const base = pure + suffix
+    const addVariants = (base: string): void => {
       candidates.add(base)
       candidates.add(base + bpSuffix)
       candidates.add(`${base}blueprint`)
       candidates.add(base + setSuffix)
       candidates.add(`${base}set`)
+    }
+
+    addVariants(input)
+    for (const resolvedSuffix of resolvePartSuffixes(suffix)) {
+      if (!resolvedSuffix) {
+        continue
+      }
+
+      addVariants(pure + resolvedSuffix)
     }
 
     return [...candidates]

--- a/tests/services/wfm/wm.wfm.matcher.spec.ts
+++ b/tests/services/wfm/wm.wfm.matcher.spec.ts
@@ -14,11 +14,17 @@ describe('wfm-item-matcher helpers', () => {
   describe('removeNameSuffix', () => {
     const cases = [
       { input: 'Volt Prime 头', pure: 'voltprime', suffix: '头部神经光元' },
+      { input: 'Volt Prime 头部', pure: 'voltprime', suffix: '头部神经光元' },
       { input: 'Rhino Prime 机体', pure: 'rhinoprime', suffix: '机体' },
       { input: 'Volt Prime 系统', pure: 'voltprime', suffix: '系统' },
       { input: 'Volt Prime 蓝图', pure: 'voltprime', suffix: '蓝图' },
       { input: 'Volt Prime 总图', pure: 'voltprime', suffix: '蓝图' },
       { input: '夜灵总图', pure: '夜灵', suffix: '蓝图' },
+      { input: '重击巨锤 Prime 锤头', pure: '重击巨锤prime', suffix: '锤头' },
+      { input: '凯旋之爪 Prime 爪刃', pure: '凯旋之爪prime', suffix: '爪刃' },
+      { input: '帕里斯 Prime 弓身', pure: '帕里斯prime', suffix: '弓身' },
+      { input: '蛟龙 Prime 外壳', pure: '蛟龙prime', suffix: '外壳' },
+      { input: '蛟龙 Prime 头部', pure: '蛟龙prime', suffix: '头部神经光元' },
     ]
 
     for (const testCase of cases) {
@@ -65,6 +71,11 @@ describe('wfm-item-matcher helpers', () => {
           'voltprime头部神经光元blueprint',
           'voltprime头部神经光元一套',
           'voltprime头部神经光元set',
+          'voltprime头部',
+          'voltprime头部蓝图',
+          'voltprime头部blueprint',
+          'voltprime头部一套',
+          'voltprime头部set',
         ],
       },
       {
@@ -80,6 +91,11 @@ describe('wfm-item-matcher helpers', () => {
           'dj头部神经光元blueprint',
           'dj头部神经光元一套',
           'dj头部神经光元set',
+          'dj头部',
+          'dj头部蓝图',
+          'dj头部blueprint',
+          'dj头部一套',
+          'dj头部set',
         ],
       },
     ]
@@ -90,6 +106,14 @@ describe('wfm-item-matcher helpers', () => {
         expect(result).to.deep.equal(testCase.expected)
       })
     }
+
+    it('expands 头 to both neuroptics and cerebrum suffixes', () => {
+      const result = buildSuffixVariantCandidates(normalizeName('Volt Prime 头'))
+      expect(result).to.include('voltprime头部神经光元')
+      expect(result).to.include('voltprime头部')
+      expect(result).to.include('voltprime头部神经光元蓝图')
+      expect(result).to.include('voltprime头部蓝图')
+    })
   })
 
   describe('word prefix tokenizer', () => {

--- a/tests/services/wfm/wm.wfm.spec.ts
+++ b/tests/services/wfm/wm.wfm.spec.ts
@@ -103,6 +103,7 @@ describe('wfm-service.inputToItem', () => {
   const suffixCases = [
     { input: 'Volt Prime 系统', slug: 'volt_prime_systems_blueprint' },
     { input: 'Volt Prime 头', slug: 'volt_prime_neuroptics_blueprint' },
+    { input: 'Volt Prime 头部', slug: 'volt_prime_neuroptics_blueprint' },
     { input: 'Volt Prime 机体', slug: 'volt_prime_chassis_blueprint' },
     { input: 'Rhino Prime 头', slug: 'rhino_prime_neuroptics_blueprint' },
     { input: 'Rhino Prime 机体', slug: 'rhino_prime_chassis_blueprint' },
@@ -112,6 +113,28 @@ describe('wfm-service.inputToItem', () => {
     { input: 'Mag Prime 头', slug: 'mag_prime_neuroptics_blueprint' },
     { input: 'Frost Prime 头', slug: 'frost_prime_neuroptics_blueprint' },
     { input: 'Ember Prime 机体', slug: 'ember_prime_chassis_blueprint' },
+    { input: '蛟龙 Prime 头', slug: 'wyrm_prime_cerebrum' },
+    { input: '蛟龙头', slug: 'wyrm_prime_cerebrum' },
+    { input: '死亡魔方 Prime 头', slug: 'dethcube_prime_cerebrum' },
+    { input: '重击巨锤 Prime 锤头', slug: 'fragor_prime_head' },
+    { input: '帕里斯 Prime 弓身', slug: 'paris_prime_grip' },
+    { input: '蛟龙 Prime 外壳', slug: 'wyrm_prime_carapace' },
+    { input: '飞扬 Prime 镖袋', slug: 'hikou_prime_pouch' },
+    { input: '凯旋之爪 Prime 爪刃', slug: 'venka_prime_blades' },
+    { input: '红隼 Prime 握把', slug: 'kestrel_prime_grip' },
+    { input: '陨蜓 Prime 外甲', slug: 'odonata_prime_harness_blueprint' },
+    { input: '陨蜓 Prime 机翼', slug: 'odonata_prime_wings_blueprint' },
+    { input: '喀婆萨 Prime 项圈扣', slug: 'kavasa_prime_buckle' },
+  ]
+
+  const relicOmitCases = [
+    { input: '后纪H3', slug: 'axi_h3_relic' },
+    { input: '后纪 H3', slug: 'axi_h3_relic' },
+    { input: 'Axi H3', slug: 'axi_h3_relic' },
+    { input: 'AxiH3', slug: 'axi_h3_relic' },
+    { input: '安魂 IV', slug: 'requiem_iv_relic' },
+    { input: '安魂IV', slug: 'requiem_iv_relic' },
+    { input: 'Requiem IV', slug: 'requiem_iv_relic' },
   ]
 
   const combinedCases = [
@@ -126,6 +149,7 @@ describe('wfm-service.inputToItem', () => {
     { input: '瓦喵头', slug: 'valkyr_prime_neuroptics_blueprint' },
     { input: '奶爸头', slug: 'oberon_prime_neuroptics_blueprint' },
     { input: 'DJ头', slug: 'octavia_prime_neuroptics_blueprint' },
+    { input: '电头部', slug: 'volt_prime_neuroptics_blueprint' },
     { input: '花图', slug: 'wisp_prime_blueprint' },
   ]
 
@@ -204,6 +228,14 @@ describe('wfm-service.inputToItem', () => {
   describe('suffix variants', () => {
     for (const testCase of suffixCases) {
       it(`normalizes ${testCase.input}`, async () => {
+        await expectItemSlug(testCase.input, testCase.slug)
+      })
+    }
+  })
+
+  describe('omitted relic suffix', () => {
+    for (const testCase of relicOmitCases) {
+      it(`resolves ${testCase.input}`, async () => {
         await expectItemSlug(testCase.input, testCase.slug)
       })
     }


### PR DESCRIPTION
Head shorthand now expands 头部 to neuroptics first, then sentinel cerebrum, and compact relic queries like 后纪H3 resolve without 遗物.