### PR TITLE
fix(wf): show Archon Hunt missions in weekly output

### DIFF
--- a/src/components/wf.tsx
+++ b/src/components/wf.tsx
@@ -713,9 +713,33 @@ export function WeeklyComponent(archon: ArchonHunt, deepArchimedea: ArchiMedea, 
         Archon Hunt
       </div>
 
-      <div style="font-size:16px;font-weight:600;color:var(--wf-text-primary);">
-        {`执行官刺杀: ${archon.name}`}
+      <div style="font-size:16px;font-weight:600;color:var(--wf-text-primary);margin-bottom:8px;">
+        {`${archon.modeName}: ${archon.name}`}
       </div>
+
+      {archon.missions.map((mission) => {
+        const location = [mission.node.system, mission.node.name, mission.node.faction]
+          .filter(Boolean)
+          .join(' · ')
+        const levels = mission.node.minLevel && mission.node.maxLevel
+          ? `Lv.${mission.node.minLevel}-${mission.node.maxLevel}`
+          : ''
+
+        return (
+          <div style={missionCardStyle}>
+            <div style="font-size:13px;font-weight:600;margin-bottom:4px;color:var(--wf-text-body);">
+              {mission.type}
+            </div>
+            {location || levels
+              ? (
+                  <div style="font-size:12px;color:var(--wf-text-secondary);">
+                    {[location, levels].filter(Boolean).join(' · ')}
+                  </div>
+                )
+              : null}
+          </div>
+        )
+      })}
     </section>
   )
 

--- a/src/warframe/data/wf/archonHunt.ts
+++ b/src/warframe/data/wf/archonHunt.ts
@@ -1,0 +1,18 @@
+import { dict_zh } from 'warframe-public-export-plus'
+import { dictZhExtra } from '../../assets/index'
+
+const MODE_NAME_KEY = '/Lotus/Language/WorldStateWindow/LiteSortieMissionName'
+
+const HUNT_ENEMY_LEVELS: Array<{ minLevel: number, maxLevel: number }> = [
+  { minLevel: 130, maxLevel: 135 },
+  { minLevel: 135, maxLevel: 140 },
+  { minLevel: 145, maxLevel: 150 },
+]
+
+export function getArchonHuntModeName(): string {
+  return dict_zh[MODE_NAME_KEY] ?? dictZhExtra[MODE_NAME_KEY] ?? MODE_NAME_KEY
+}
+
+export function getArchonHuntEnemyLevels(index: number): { minLevel: number, maxLevel: number } {
+  return HUNT_ENEMY_LEVELS[index] ?? HUNT_ENEMY_LEVELS[HUNT_ENEMY_LEVELS.length - 1]
+}

--- a/src/warframe/services/wf-service.ts
+++ b/src/warframe/services/wf-service.ts
@@ -6,6 +6,7 @@ import type {
   ArchiMedeaDebuff,
   ArchiMedeaMission,
   ArchonHunt,
+  ArchonHuntMissions,
   BountyBoard,
   BountyLocation,
   Fissure,
@@ -35,6 +36,10 @@ import {
   warframes as warframeRewards,
 } from '../assets/index'
 import { arbitrationSchedule } from '../data/wf/arbitrationSchedule'
+import {
+  getArchonHuntEnemyLevels,
+  getArchonHuntModeName,
+} from '../data/wf/archonHunt'
 import { globalOracleBountyCycle } from '../data/wf/globalOracleBountyCycle'
 import { globalWorldState } from '../data/wf/globalWorldState'
 import { relics } from '../data/wf/relics'
@@ -53,6 +58,7 @@ import {
 import { regionToShort } from '../infrastructure/wf/wf-export-adapter'
 import {
   getMissionTypeKey,
+  getSolNodeKey,
   getVoidTraderItem,
 } from '../infrastructure/wf/wfcd-adapter'
 import { failure } from '../types/warframe-result'
@@ -157,6 +163,55 @@ export function getArbitrations(day: number = 3): WarframeResult<Arbitration[]> 
   }
 }
 
+export async function adaptArchonHunt(source: {
+  boss: string
+  missions?: Array<{
+    type: string
+    node?: string
+    nodeKey: string
+  }>
+}): Promise<ArchonHunt> {
+  const name = dict_zh[
+    `/Lotus/Language/Narmer/${removeSpace(source.boss)}`
+  ] ?? source.boss
+
+  const missions = await Promise.all(
+    (source.missions ?? []).map(async (mission, index): Promise<ArchonHuntMissions> => {
+      const receivedType = await getMissionTypeKey(mission.type)
+      const type = dict_zh[ExportMissionTypes[receivedType]?.name ?? ''] ?? mission.type
+      const solNodeKey = await getSolNodeKey(mission.nodeKey)
+      const region = solNodeKey ? ExportRegions[solNodeKey] : undefined
+      const levels = getArchonHuntEnemyLevels(index)
+
+      const node = region
+        ? regionToShort(region, dict_zh)
+        : {
+            name: mission.node ?? mission.nodeKey,
+            system: '',
+            type: '',
+            faction: '',
+            minLevel: 0,
+            maxLevel: 0,
+          }
+
+      return {
+        type,
+        node: {
+          ...node,
+          minLevel: levels.minLevel,
+          maxLevel: levels.maxLevel,
+        },
+      }
+    }),
+  )
+
+  return {
+    modeName: getArchonHuntModeName(),
+    name,
+    missions,
+  }
+}
+
 export async function getWeekly(): Promise<WarframeResult<{
   archonHunt: ArchonHunt
   deepArchimedea: ArchiMedea
@@ -167,12 +222,7 @@ export async function getWeekly(): Promise<WarframeResult<{
     return failure('common.fetchFailed', true)
   }
 
-  const archon: ArchonHunt = {
-    name: dict_zh[
-      `/Lotus/Language/Narmer/${removeSpace(worldState.archonHunt.boss)}`
-    ],
-    missions: [],
-  }
+  const archon = await adaptArchonHunt(worldState.archonHunt)
 
   const stringToDebuff = (
     key: string,

--- a/src/warframe/types/wf/weekly.ts
+++ b/src/warframe/types/wf/weekly.ts
@@ -1,6 +1,7 @@
 import type { WFRegionShort } from './region'
 
 export interface ArchonHunt {
+  modeName: string
   name: string
   missions: ArchonHuntMissions[]
 }

--- a/tests/components/weekly.wf.spec.ts
+++ b/tests/components/weekly.wf.spec.ts
@@ -1,0 +1,72 @@
+import type { ArchiMedea, ArchonHunt } from '../../src/warframe'
+import { expect } from 'chai'
+import { WeeklyComponent } from '../../src/components/wf'
+
+const emptyArchimedea: ArchiMedea = {
+  name: '深层科研',
+  missions: [],
+  peronal: [],
+}
+
+function mission(type: string): ArchonHunt['missions'][number] {
+  return {
+    type,
+    node: {
+      name: 'Galatea',
+      system: '海王星',
+      type: '捕获',
+      faction: 'Corpus',
+      minLevel: 130,
+      maxLevel: 135,
+    },
+  }
+}
+
+describe('weeklyComponent tests', () => {
+  it('lays out archon hunt missions as sibling cards', () => {
+    const archon: ArchonHunt = {
+      modeName: '执刑官猎杀',
+      name: '执刑官诡文枭主',
+      missions: [
+        mission('歼灭'),
+        mission('防御'),
+        mission('刺杀'),
+      ],
+    }
+
+    const html = String(WeeklyComponent(
+      archon,
+      emptyArchimedea,
+      { ...emptyArchimedea, name: '时光科研' },
+    ))
+
+    expect(html).to.include('歼灭')
+    expect(html).to.include('防御')
+    expect(html).to.include('刺杀')
+    expect(html).to.not.match(/<div[^>]*\/>/)
+  })
+
+  it('renders archon hunt missions with type and location', () => {
+    const archon: ArchonHunt = {
+      modeName: '执刑官猎杀',
+      name: '执刑官诡文枭主',
+      missions: [mission('歼灭')],
+    }
+
+    const html = String(WeeklyComponent(
+      archon,
+      emptyArchimedea,
+      { ...emptyArchimedea, name: '时光科研' },
+    ))
+
+    expect(html).to.include('执刑官猎杀')
+    expect(html).to.include('执刑官诡文枭主')
+    expect(html).to.include('歼灭')
+    expect(html).to.include('海王星')
+    expect(html).to.include('Galatea')
+    expect(html).to.include('Corpus')
+    expect(html).to.include('Lv.130-135')
+    expect(html).to.not.include('关卡:')
+    expect(html).to.not.include('特殊:')
+  })
+})

--- a/tests/services/wf/archon-hunt.wf.spec.ts
+++ b/tests/services/wf/archon-hunt.wf.spec.ts
@@ -1,0 +1,100 @@
+import { expect } from 'chai'
+import { dict_zh } from 'warframe-public-export-plus'
+import { dictZhExtra } from '../../../src/warframe/assets'
+import { adaptArchonHunt } from '../../../src/warframe/services'
+
+function translateLotus(key: string): string | undefined {
+  return dict_zh[key] ?? dictZhExtra[key]
+}
+
+describe('adaptArchonHunt Tests', () => {
+  it('translates the archon name and a resolved mission type and node', async () => {
+    const result = await adaptArchonHunt({
+      boss: 'Archon Boreal',
+      missions: [
+        {
+          type: 'Extermination',
+          node: 'Galatea (Neptune)',
+          nodeKey: 'Galatea (Neptune)',
+        },
+      ],
+    })
+
+    expect(result.modeName).to.equal(
+      translateLotus('/Lotus/Language/WorldStateWindow/LiteSortieMissionName'),
+    )
+    expect(result.name).to.equal('执刑官诡文枭主')
+    expect(result.missions).to.have.length(1)
+    expect(result.missions[0].type).to.equal('歼灭')
+    expect(result.missions[0].node.name).to.equal('Galatea')
+    expect(result.missions[0].node.system).to.equal('海王星')
+    expect(result.missions[0].node.faction).to.equal('Corpus')
+  })
+
+  it('keeps mission order and translates each hunt mission type', async () => {
+    const result = await adaptArchonHunt({
+      boss: 'Archon Amar',
+      missions: [
+        { type: 'Extermination', nodeKey: 'Galatea (Neptune)' },
+        { type: 'Defense', nodeKey: 'Aphrodite (Venus)' },
+        { type: 'Assassination', nodeKey: 'Acheron (Pluto)' },
+      ],
+    })
+
+    expect(result.missions.map(mission => mission.type)).to.deep.equal(['歼灭', '防御', '刺杀'])
+  })
+
+  it('falls back to the provided node name when the sol node cannot be resolved', async () => {
+    const result = await adaptArchonHunt({
+      boss: 'Archon Nira',
+      missions: [
+        {
+          type: 'Extermination',
+          node: 'Unknown Node (Nowhere)',
+          nodeKey: 'Unknown Node (Nowhere)',
+        },
+      ],
+    })
+
+    expect(result.missions[0].type).to.equal('歼灭')
+    expect(result.missions[0].node.name).to.equal('Unknown Node (Nowhere)')
+    expect(result.missions[0].node.system).to.equal('')
+  })
+
+  it('keeps the original mission type when it cannot be translated', async () => {
+    const result = await adaptArchonHunt({
+      boss: 'Archon Boreal',
+      missions: [
+        { type: 'NotARealMissionType', nodeKey: 'Galatea (Neptune)' },
+      ],
+    })
+
+    expect(result.missions[0].type).to.equal('NotARealMissionType')
+  })
+
+  it('returns an empty mission list when the source has none', async () => {
+    const result = await adaptArchonHunt({
+      boss: 'Archon Boreal',
+    })
+
+    expect(result.name).to.equal('执刑官诡文枭主')
+    expect(result.missions).to.deep.equal([])
+  })
+
+  it('adds hunt enemy levels by mission index', async () => {
+    const result = await adaptArchonHunt({
+      boss: 'Archon Amar',
+      missions: [
+        { type: 'Rescue', nodeKey: 'Galatea (Neptune)' },
+        { type: 'Defense', nodeKey: 'Aphrodite (Venus)' },
+        { type: 'Assassination', nodeKey: 'Acheron (Pluto)' },
+      ],
+    })
+
+    expect(result.missions[0].node.minLevel).to.equal(130)
+    expect(result.missions[0].node.maxLevel).to.equal(135)
+    expect(result.missions[1].node.minLevel).to.equal(135)
+    expect(result.missions[2].node.minLevel).to.equal(145)
+    expect(result.missions[2].node.maxLevel).to.equal(150)
+  })
+})


### PR DESCRIPTION
The weekly command listed the hunt boss but left missions empty. Map each LiteSortie stage from export-plus names, nodes, and hunt enemy levels so the card shows the actual rotation.