### PR TITLE
feat(wf): add Nightwave command with official Chinese challenges

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -115,6 +115,11 @@ export function setupCommands(ctx: Context, deps: PluginDependencies): void {
     .alias('执行官')
     .action(wf.weeklyCommand)
   ctx
+    .command('nightwave', '当前午夜电波')
+    .alias('电波')
+    .alias('午夜电波')
+    .action(wf.nightwaveCommand)
+  ctx
     .command('circuit', '本周回廊战甲及灵化之源')
     .alias('灵化之源')
     .alias('灵化')

--- a/src/commands/wf.ts
+++ b/src/commands/wf.ts
@@ -5,6 +5,7 @@ import {
   BountyComponent,
   CircuitComponent,
   FissureComponent,
+  NightwaveComponent,
   RelicComponent,
   RivenComponent,
   RivenStatComponent,
@@ -21,6 +22,7 @@ import {
   getCircuitWeek,
   getEnvironment,
   getFissures,
+  getNightwave,
   getRailjackFissures,
   getRelic,
   getStaticRivenStats,
@@ -46,6 +48,7 @@ export function createWfCommands(deps: PluginDependencies): {
     disposition: number,
   ) => Promise<string>
   weeklyCommand: (_action: Argv) => Promise<string>
+  nightwaveCommand: (_action: Argv) => Promise<string>
   weeklyRivenCommand: (_action: Argv, minPrice?: number) => Promise<string>
   environmentCommand: () => Promise<string>
   bountyCetusCommand: () => Promise<string>
@@ -191,6 +194,15 @@ export function createWfCommands(deps: PluginDependencies): {
           result.data.temporalArchimedea,
         ),
       )
+    },
+
+    nightwaveCommand: async (_action: Argv) => {
+      const result = await getNightwave()
+      if (!result.ok) {
+        return t(result)
+      }
+
+      return render(NightwaveComponent(result.data))
     },
 
     weeklyRivenCommand: async (_action: Argv, minPrice?: number) => {

--- a/src/components/wf.tsx
+++ b/src/components/wf.tsx
@@ -6,6 +6,7 @@ import type {
   ArchonHunt,
   BountyBoard,
   Fissure,
+  NightwaveBoard,
   OutputRelic,
   OutputRelicReward,
   RelicRewardRarity,
@@ -859,6 +860,65 @@ export function WeeklyComponent(archon: ArchonHunt, deepArchimedea: ArchiMedea, 
       {archonHuntSection}
       {deepArchimedeaSection}
       {temporalArchimedeaSection}
+    </div>
+  )
+}
+
+export function NightwaveComponent(board: NightwaveBoard): Element {
+  const kindLabel = {
+    daily: '每日',
+    weekly: '每周',
+    elite: '精英',
+    permanent: '精选',
+  } as const
+
+  return (
+    <div
+      style="width:560px;background-color:var(--wf-bg-card);border-radius:var(--wf-radius);padding:10px 12px;box-shadow:var(--wf-shadow-card);border:1px solid var(--wf-border);font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;color:var(--wf-text-body);"
+    >
+      <h1 style="font-size:18px;font-weight:bold;color:var(--wf-text-primary);margin:0 0 2px 0;text-align:center;">
+        {board.title}
+      </h1>
+      <div style="text-align:center;font-size:12px;color:var(--wf-text-secondary);margin-bottom:2px;">
+        {`第${board.season + 1}季 · 剩余${board.remaining}`}
+      </div>
+      <div style="text-align:center;font-size:10px;color:var(--wf-text-muted);margin-bottom:8px;">
+        剩余时间不准确，最多可能偏差数月
+      </div>
+      <div style="display:flex;flex-direction:column;gap:4px;">
+        {board.challenges.map(challenge => (
+          <div
+            style="padding:6px 8px;background-color:var(--wf-bg-subtle);border-radius:var(--wf-radius-sm);"
+          >
+            <div style="display:flex;align-items:baseline;gap:8px;flex-wrap:wrap;">
+              <span style="font-size:11px;color:var(--wf-accent);">
+                {kindLabel[challenge.kind]}
+              </span>
+              <span style="font-size:13px;font-weight:700;color:var(--wf-text-primary);flex:1;">
+                {challenge.name}
+              </span>
+              {challenge.standing === undefined
+                ? null
+                : (
+                    <span style="font-size:11px;color:var(--wf-accent);">
+                      {`${challenge.standing} 声望`}
+                    </span>
+                  )}
+              <span style="font-size:11px;color:var(--wf-text-muted);">
+                剩余
+                {challenge.remaining}
+              </span>
+            </div>
+            {challenge.description
+              ? (
+                  <div style="font-size:11px;line-height:1.35;color:var(--wf-text-body);margin-top:2px;">
+                    {challenge.description}
+                  </div>
+                )
+              : null}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -10,6 +10,7 @@ export const messages = {
   'arbitration.invalidDayRange': '天数需小于等于14且大于0',
 
   'bounty.unavailable': '当前该地点暂无可用赏金',
+  'nightwave.unavailable': '当前没有午夜电波',
 
   'voidTrader.drifting': '虚空商人仍在未知地带漂流...',
   'voidTrader.arriving': '距离虚空商人到达还有: {time}',

--- a/src/warframe/data/wf/globalWorldState.ts
+++ b/src/warframe/data/wf/globalWorldState.ts
@@ -1,8 +1,9 @@
 import type WorldState from 'warframe-worldstate-parser'
-import type { Fissure, RawSyndicateMission } from '../../types'
+import type { Fissure, RawSeasonInfo, RawSyndicateMission } from '../../types'
 
 import { dict_zh, ExportRegions } from 'warframe-public-export-plus'
 import {
+  extractSeasonInfoRaw,
   extractSyndicateMissionsRaw,
   fetchWorldStateJson,
   getWorldState,
@@ -48,6 +49,7 @@ export const globalWorldState = createAsyncCache(async () => {
   }
 
   const syndicateMissionsRaw: RawSyndicateMission[] = extractSyndicateMissionsRaw(json)
+  const seasonInfoRaw: RawSeasonInfo | undefined = extractSeasonInfoRaw(json)
   const worldState = await getWorldState(json)
   const fissures: Fissure[] = []
   const rjFissures: Fissure[] = []
@@ -72,6 +74,7 @@ export const globalWorldState = createAsyncCache(async () => {
   return {
     raw: worldState,
     syndicateMissionsRaw,
+    seasonInfoRaw,
     fissures,
     spFissures,
     rjFissures,

--- a/src/warframe/infrastructure/wf/nightwave-adapter.ts
+++ b/src/warframe/infrastructure/wf/nightwave-adapter.ts
@@ -1,0 +1,122 @@
+import type {
+  NightwaveBoard,
+  NightwaveChallengeInfo,
+  NightwaveChallengeKind,
+  RawMongoDate,
+  RawNightwaveActiveChallenge,
+  RawSeasonInfo,
+} from '../../types'
+import {
+  dict_zh,
+  ExportNightwave,
+  ExportSyndicates,
+} from 'warframe-public-export-plus'
+import { dictZhExtra } from '../../assets/index'
+import { msToHumanReadable } from '../../utils'
+
+const RADIO_LEGION_TITLE_KEY = '/Lotus/Language/Syndicates/RadioLegionTitle'
+
+function timestampMs(value?: RawMongoDate): number {
+  const raw = value?.$date?.$numberLong
+  if (raw === undefined || raw === '') {
+    return 0
+  }
+  const ms = Number(raw)
+  return Number.isFinite(ms) ? ms : 0
+}
+
+function remainingLabel(expiry: number, now: number): string {
+  return msToHumanReadable(Math.max(expiry - now, 0))
+}
+
+function translate(key: string): string {
+  return dict_zh[key] ?? dictZhExtra[key] ?? key
+}
+
+function seasonTitle(affiliationTag: string): string {
+  const syndicate = ExportSyndicates[affiliationTag]
+  if (syndicate?.name) {
+    return translate(syndicate.name)
+  }
+  return translate(RADIO_LEGION_TITLE_KEY)
+}
+
+function classifyChallenge(
+  path: string,
+  raw: RawNightwaveActiveChallenge,
+): NightwaveChallengeKind {
+  if (raw.Daily || path.includes('/Daily/')) {
+    return 'daily'
+  }
+  if (raw.Permanent || /permanent/i.test(path)) {
+    return 'permanent'
+  }
+  if (/hard/i.test(path)) {
+    return 'elite'
+  }
+  return 'weekly'
+}
+
+function challengeFallbackName(path: string): string {
+  return path.split('/').pop() ?? path
+}
+
+function adaptChallenge(
+  raw: RawNightwaveActiveChallenge,
+  now: number,
+): NightwaveChallengeInfo | undefined {
+  const path = raw.Challenge
+  if (!path) {
+    return undefined
+  }
+
+  const expiry = timestampMs(raw.Expiry)
+  if (expiry <= now) {
+    return undefined
+  }
+
+  const kind = classifyChallenge(path, raw)
+  const remaining = remainingLabel(expiry, now)
+  const exported = ExportNightwave.challenges[path]
+  if (!exported) {
+    return {
+      name: challengeFallbackName(path),
+      description: '',
+      kind,
+      remaining,
+    }
+  }
+
+  const description = translate(exported.description)
+    .split('|COUNT|')
+    .join(String(exported.required))
+
+  return {
+    name: translate(exported.name),
+    description,
+    kind,
+    remaining,
+    standing: exported.standing,
+  }
+}
+
+export function adaptNightwave(raw: RawSeasonInfo, now: number = Date.now()): NightwaveBoard {
+  const expiry = timestampMs(raw.Expiry)
+  const challenges: NightwaveChallengeInfo[] = []
+
+  for (const entry of raw.ActiveChallenges) {
+    const adapted = adaptChallenge(entry, now)
+    if (adapted) {
+      challenges.push(adapted)
+    }
+  }
+
+  return {
+    title: seasonTitle(raw.AffiliationTag),
+    season: raw.Season,
+    phase: raw.Phase,
+    expiry,
+    remaining: remainingLabel(expiry, now),
+    challenges,
+  }
+}

--- a/src/warframe/infrastructure/wf/wf-api.ts
+++ b/src/warframe/infrastructure/wf/wf-api.ts
@@ -1,5 +1,5 @@
 import type WorldState from 'warframe-worldstate-parser'
-import type { OracleBountyCycle, RawSyndicateMission } from '../../types'
+import type { OracleBountyCycle, RawSeasonInfo, RawSyndicateMission } from '../../types'
 
 import { Baro } from '../../assets/index'
 import { fetchAsyncData, fetchAsyncText } from '../../utils'
@@ -14,6 +14,23 @@ export function extractSyndicateMissionsRaw(json: string): RawSyndicateMission[]
   }
   catch {
     return []
+  }
+}
+
+export function extractSeasonInfoRaw(json: string): RawSeasonInfo | undefined {
+  try {
+    const data = JSON.parse(json) as { SeasonInfo?: RawSeasonInfo }
+    const info = data.SeasonInfo
+    if (!info || typeof info !== 'object') {
+      return undefined
+    }
+    return {
+      ...info,
+      ActiveChallenges: Array.isArray(info.ActiveChallenges) ? info.ActiveChallenges : [],
+    }
+  }
+  catch {
+    return undefined
   }
 }
 

--- a/src/warframe/services/wf-service.ts
+++ b/src/warframe/services/wf-service.ts
@@ -10,7 +10,9 @@ import type {
   BountyBoard,
   BountyLocation,
   Fissure,
+  NightwaveBoard,
   OcrAPISecret,
+  RawSeasonInfo,
   Relic,
   RivenAttribute,
   RivenStatAnalyzeResult,
@@ -55,6 +57,7 @@ import {
   findRawSyndicateMission,
   oracleBountyLocations,
 } from '../infrastructure/wf/bounty-adapter'
+import { adaptNightwave } from '../infrastructure/wf/nightwave-adapter'
 import { regionToShort } from '../infrastructure/wf/wf-export-adapter'
 import {
   getMissionTypeKey,
@@ -320,6 +323,27 @@ export async function getWeekly(): Promise<WarframeResult<{
       deepArchimedea: deepArchimRes,
       temporalArchimedea: temporalArchimRes,
     },
+  }
+}
+
+export function resolveNightwave(
+  raw: RawSeasonInfo | undefined,
+  now: number = Date.now(),
+): WarframeResult<NightwaveBoard> {
+  if (!raw) {
+    return failure('nightwave.unavailable')
+  }
+
+  return { ok: true, data: adaptNightwave(raw, now) }
+}
+
+export async function getNightwave(): Promise<WarframeResult<NightwaveBoard>> {
+  try {
+    const { seasonInfoRaw } = await globalWorldState.get()
+    return resolveNightwave(seasonInfoRaw)
+  }
+  catch {
+    return failure('common.fetchFailed', true)
   }
 }
 

--- a/src/warframe/types/index.ts
+++ b/src/warframe/types/index.ts
@@ -27,6 +27,14 @@ export type {
   RawSyndicateMission,
 } from './wf/bounty'
 export type { Fissure } from './wf/fissure'
+export type {
+  NightwaveBoard,
+  NightwaveChallengeInfo,
+  NightwaveChallengeKind,
+  RawMongoDate,
+  RawNightwaveActiveChallenge,
+  RawSeasonInfo,
+} from './wf/nightwave'
 export type { WFRegion, WFRegionShort } from './wf/region'
 export type {
   ExternalRelic,

--- a/src/warframe/types/warframe-result.ts
+++ b/src/warframe/types/warframe-result.ts
@@ -5,6 +5,7 @@ export const warframeErrorCodes = [
   'relic.notFound',
   'arbitration.invalidDayRange',
   'bounty.unavailable',
+  'nightwave.unavailable',
   'voidTrader.drifting',
   'voidTrader.arriving',
   'riven.imageFetchFailed',

--- a/src/warframe/types/wf/nightwave.ts
+++ b/src/warframe/types/wf/nightwave.ts
@@ -1,0 +1,38 @@
+export interface RawMongoDate {
+  $date?: { $numberLong?: string | number }
+}
+
+export interface RawNightwaveActiveChallenge {
+  Challenge: string
+  Daily?: boolean
+  Permanent?: boolean | number | string
+  Activation?: RawMongoDate
+  Expiry?: RawMongoDate
+}
+
+export interface RawSeasonInfo {
+  Season: number
+  Phase: number
+  AffiliationTag: string
+  Expiry?: RawMongoDate
+  ActiveChallenges: RawNightwaveActiveChallenge[]
+}
+
+export type NightwaveChallengeKind = 'daily' | 'weekly' | 'elite' | 'permanent'
+
+export interface NightwaveChallengeInfo {
+  name: string
+  description: string
+  kind: NightwaveChallengeKind
+  remaining: string
+  standing?: number
+}
+
+export interface NightwaveBoard {
+  title: string
+  season: number
+  phase: number
+  expiry: number
+  remaining: string
+  challenges: NightwaveChallengeInfo[]
+}

--- a/tests/components/nightwave.wf.spec.ts
+++ b/tests/components/nightwave.wf.spec.ts
@@ -1,0 +1,106 @@
+import type { NightwaveBoard } from '../../src/warframe'
+import { expect } from 'chai'
+import { NightwaveComponent } from '../../src/components/wf'
+
+function board(overrides: Partial<NightwaveBoard> = {}): NightwaveBoard {
+  return {
+    title: '午夜电波',
+    season: 16,
+    phase: 0,
+    expiry: Date.now() + 10 * 86_400_000,
+    remaining: '10天',
+    challenges: [
+      {
+        name: '交流者',
+        description: '标记 5 个 Mod 或资源。',
+        kind: 'daily',
+        remaining: '1天',
+        standing: 1000,
+      },
+      {
+        name: '重型火炮',
+        description: '使用曲翼枪械击杀 500 名敌人',
+        kind: 'weekly',
+        remaining: '5天',
+        standing: 4500,
+      },
+      {
+        name: '资源清道夫',
+        description: '收集 20 种不同类型的资源。',
+        kind: 'elite',
+        remaining: '5天',
+        standing: 7000,
+      },
+      {
+        name: '任务完成 IX',
+        description: '完成 15 项任务',
+        kind: 'permanent',
+        remaining: '5天',
+        standing: 4500,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('nightwaveComponent tests', () => {
+  it('renders a flat list with kind, names, standing, and remaining time on each act', () => {
+    const html = String(NightwaveComponent(board()))
+
+    expect(html).to.include('午夜电波')
+    expect(html).to.include('第17季 · 剩余10天')
+    expect(html).to.not.include('赛季剩余')
+    expect(html).to.not.include('阶段')
+    expect(html).to.include('不准确')
+    expect(html).to.include('数月')
+    expect(html).to.not.include('非官方')
+    expect(html).to.not.include('border-left')
+
+    expect(html).to.include('每日')
+    expect(html).to.include('每周')
+    expect(html).to.include('精英')
+    expect(html).to.include('精选')
+
+    expect(html).to.include('交流者')
+    expect(html).to.include('标记 5 个 Mod 或资源。')
+    expect(html).to.include('1000')
+    expect(html).to.include('1天')
+
+    expect(html).to.include('重型火炮')
+    expect(html).to.include('4500')
+
+    expect(html).to.include('资源清道夫')
+    expect(html).to.include('7000')
+
+    expect(html).to.include('任务完成 IX')
+    expect(html).to.not.match(/<div[^>]*\/>/)
+    expect(html).to.not.match(/<section[\s>]/)
+  })
+
+  it('omits unused kind labels when those acts are absent', () => {
+    const html = String(NightwaveComponent(board({
+      challenges: [
+        {
+          name: '交流者',
+          description: '标记 5 个 Mod 或资源。',
+          kind: 'daily',
+          remaining: '1天',
+          standing: 1000,
+        },
+        {
+          name: '重型火炮',
+          description: '使用曲翼枪械击杀 500 名敌人',
+          kind: 'weekly',
+          remaining: '5天',
+          standing: 4500,
+        },
+      ],
+    })))
+
+    expect(html).to.include('每日')
+    expect(html).to.include('每周')
+    expect(html).to.not.include('精英')
+    expect(html).to.not.include('精选')
+    expect(html).to.not.match(/<div[^>]*\/>/)
+  })
+})

--- a/tests/services/wf/nightwave.wf.spec.ts
+++ b/tests/services/wf/nightwave.wf.spec.ts
@@ -1,0 +1,178 @@
+import type { RawSeasonInfo } from '../../../src/warframe/types'
+import { expect } from 'chai'
+import { dict_zh, ExportNightwave } from 'warframe-public-export-plus'
+import { t } from '../../../src/i18n'
+import { extractSeasonInfoRaw } from '../../../src/warframe/infrastructure/wf/wf-api'
+import { resolveNightwave } from '../../../src/warframe/services'
+import { msToHumanReadable } from '../../../src/warframe/utils/time'
+import worldStateJSON from '../../assets/example-world-state.json'
+
+const NOW = Date.parse('2026-01-15T12:00:00Z')
+
+const DAILY_PATH = '/Lotus/Types/Challenges/Seasons/Daily/SeasonDailyPlaceMarker'
+const WEEKLY_PATH = '/Lotus/Types/Challenges/Seasons/Weekly/SeasonWeeklyKillArchgunEnemies'
+const ELITE_PATH = '/Lotus/Types/Challenges/Seasons/WeeklyHard/SeasonWeeklyHardCollectUniqueResources'
+const PERMANENT_PATH = '/Lotus/Types/Challenges/Seasons/Weekly/SeasonWeeklyPermanentCompleteMissions9'
+const UNKNOWN_PATH = '/Lotus/Types/Challenges/Seasons/Weekly/SeasonWeeklyNotARealChallenge'
+
+function mongoDate(ms: number): { $date: { $numberLong: string } } {
+  return { $date: { $numberLong: String(ms) } }
+}
+
+function challenge(
+  path: string,
+  expiry: number,
+  extra: { Daily?: boolean, Permanent?: boolean } = {},
+): RawSeasonInfo['ActiveChallenges'][number] {
+  return {
+    Challenge: path,
+    Activation: mongoDate(NOW - 86_400_000),
+    Expiry: mongoDate(expiry),
+    ...extra,
+  }
+}
+
+function expectedName(path: string): string {
+  return dict_zh[ExportNightwave.challenges[path].name]
+}
+
+function expectedStanding(path: string): number {
+  return ExportNightwave.challenges[path].standing
+}
+
+function expectedDescription(path: string): string {
+  const exported = ExportNightwave.challenges[path]
+  const raw = dict_zh[exported.description] ?? exported.description
+  return raw.split('|COUNT|').join(String(exported.required))
+}
+
+function seasonFixture(overrides: Partial<RawSeasonInfo> = {}): RawSeasonInfo {
+  return {
+    Season: 16,
+    Phase: 0,
+    AffiliationTag: 'RadioLegionIntermission14Syndicate',
+    Expiry: mongoDate(NOW + 10 * 86_400_000),
+    ActiveChallenges: [
+      challenge(DAILY_PATH, NOW + 86_400_000, { Daily: true }),
+      challenge(WEEKLY_PATH, NOW + 5 * 86_400_000),
+      challenge(ELITE_PATH, NOW + 5 * 86_400_000),
+      challenge(PERMANENT_PATH, NOW + 5 * 86_400_000, { Permanent: true }),
+      challenge(DAILY_PATH, NOW - 1000, { Daily: true }),
+      challenge(UNKNOWN_PATH, NOW + 86_400_000),
+    ],
+    ...overrides,
+  }
+}
+
+describe('nightwave', () => {
+  it('extracts SeasonInfo and keeps Challenge paths from worldstate json', () => {
+    const raw = extractSeasonInfoRaw(JSON.stringify(worldStateJSON))
+
+    expect(raw).to.not.equal(undefined)
+    expect(raw!.AffiliationTag).to.equal('RadioLegionIntermission14Syndicate')
+    expect(raw!.Season).to.equal(16)
+    expect(raw!.Phase).to.equal(0)
+    expect(raw!.ActiveChallenges.some(
+      entry => entry.Challenge === DAILY_PATH && entry.Daily === true,
+    )).to.equal(true)
+    expect(raw!.ActiveChallenges.some(
+      entry => entry.Challenge === ELITE_PATH,
+    )).to.equal(true)
+    expect(raw!.ActiveChallenges.some(
+      entry => entry.Challenge.includes('Permanent'),
+    )).to.equal(true)
+  })
+
+  it('resolves official Chinese names and ExportNightwave standing', () => {
+    const result = resolveNightwave(seasonFixture(), NOW)
+
+    expect(result.ok).to.equal(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.data.title).to.equal(dict_zh['/Lotus/Language/Syndicates/RadioLegionTitle'])
+    expect(result.data.season).to.equal(16)
+    expect(result.data.phase).to.equal(0)
+
+    const daily = result.data.challenges.find(entry => entry.kind === 'daily')
+    expect(daily).to.not.equal(undefined)
+    expect(daily!.name).to.equal(expectedName(DAILY_PATH))
+    expect(daily!.description).to.equal(expectedDescription(DAILY_PATH))
+    expect(daily!.standing).to.equal(expectedStanding(DAILY_PATH))
+
+    const weekly = result.data.challenges.find(entry => entry.name === expectedName(WEEKLY_PATH))
+    expect(weekly).to.not.equal(undefined)
+    expect(weekly!.kind).to.equal('weekly')
+    expect(weekly!.standing).to.equal(expectedStanding(WEEKLY_PATH))
+
+    const elite = result.data.challenges.find(entry => entry.kind === 'elite')
+    expect(elite).to.not.equal(undefined)
+    expect(elite!.name).to.equal(expectedName(ELITE_PATH))
+    expect(elite!.standing).to.equal(expectedStanding(ELITE_PATH))
+
+    const permanent = result.data.challenges.find(entry => entry.kind === 'permanent')
+    expect(permanent).to.not.equal(undefined)
+    expect(permanent!.name).to.equal(expectedName(PERMANENT_PATH))
+    expect(permanent!.standing).to.equal(expectedStanding(PERMANENT_PATH))
+  })
+
+  it('uses SeasonInfo expiry for the season and each challenge expiry for acts', () => {
+    const result = resolveNightwave(seasonFixture(), NOW)
+
+    expect(result.ok).to.equal(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.data.expiry).to.equal(NOW + 10 * 86_400_000)
+    expect(result.data.remaining).to.equal(msToHumanReadable(10 * 86_400_000))
+
+    const daily = result.data.challenges.find(entry => entry.kind === 'daily')
+    expect(daily!.remaining).to.equal(msToHumanReadable(86_400_000))
+
+    const weekly = result.data.challenges.find(entry => entry.name === expectedName(WEEKLY_PATH))
+    expect(weekly!.remaining).to.equal(msToHumanReadable(5 * 86_400_000))
+  })
+
+  it('drops expired active challenges', () => {
+    const result = resolveNightwave(seasonFixture(), NOW)
+
+    expect(result.ok).to.equal(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.data.challenges.filter(entry => entry.kind === 'daily')).to.have.length(1)
+    expect(result.data.challenges[0].name).to.equal(expectedName(DAILY_PATH))
+  })
+
+  it('falls back to the challenge path or key for unknown Challenge paths', () => {
+    const result = resolveNightwave(seasonFixture(), NOW)
+
+    expect(result.ok).to.equal(true)
+    if (!result.ok) {
+      return
+    }
+
+    const unknown = result.data.challenges.find(entry =>
+      entry.name === UNKNOWN_PATH || entry.name === 'SeasonWeeklyNotARealChallenge',
+    )
+    expect(unknown).to.not.equal(undefined)
+    expect(unknown!.kind).to.equal('weekly')
+    expect(unknown!.name).to.not.match(/[\u4E00-\u9FFF]/)
+    expect(unknown!.standing).to.equal(undefined)
+  })
+
+  it('fails when SeasonInfo is missing', () => {
+    const extracted = extractSeasonInfoRaw('{"SyndicateMissions":[]}')
+    const result = resolveNightwave(extracted, NOW)
+
+    expect(extracted).to.equal(undefined)
+    expect(result.ok).to.equal(false)
+    if (!result.ok) {
+      expect(result.error.code).to.equal('nightwave.unavailable')
+      expect(t(result)).to.equal('当前没有午夜电波')
+    }
+  })
+})

--- a/tests/services/wf/worldStateRefresh.fixture.spec.ts
+++ b/tests/services/wf/worldStateRefresh.fixture.spec.ts
@@ -9,7 +9,7 @@ type WorldStateSnapshot = Parameters<typeof diffWorldStates>[0]
 
 async function snapshotFrom(json: unknown): Promise<WorldStateSnapshot> {
   const raw = await getWorldState(JSON.stringify(json))
-  return { raw, fissures: [], spFissures: [], rjFissures: [], syndicateMissionsRaw: [] }
+  return { raw, fissures: [], spFissures: [], rjFissures: [], syndicateMissionsRaw: [], seasonInfoRaw: undefined }
 }
 
 describe('world-state fixture comparison', () => {

--- a/tests/services/wf/worldStateRefresh.wf.spec.ts
+++ b/tests/services/wf/worldStateRefresh.wf.spec.ts
@@ -23,6 +23,7 @@ function snapshot(raw: Partial<WorldState>): WorldStateSnapshot {
     spFissures: [],
     rjFissures: [],
     syndicateMissionsRaw: [],
+    seasonInfoRaw: undefined,
   }
 }
 


### PR DESCRIPTION
## Summary
- 新增 `nightwave` / `电波` / `午夜电波` 命令，用 Puppeteer 渲染当前午夜电波赛季与进行中的每日/每周/精英/精选挑战。
- 挑战中文名、描述和声望来自 `ExportNightwave` + `dict_zh`，直接解析 worldstate 的 `SeasonInfo`，不走 parser 的英文标题。
- 赛季剩余时间会标注不准确（官方 expiry 可能偏差数月）；不展示内部 Phase。

## Test plan
- [ ] `vitest run tests/services/wf/nightwave.wf.spec.ts tests/components/nightwave.wf.spec.ts`
- [ ] 运行 `nightwave` / `电波`，确认标题、第 N 季、挑战分类与声望正确
- [ ] 确认无活跃电波时提示「当前没有午夜电波」
- [ ] 确认剩余时间脚注可见，且界面不显示 Phase
