### PR TITLE
feat(wf): add sortie command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -120,8 +120,9 @@ export function setupCommands(ctx: Context, deps: PluginDependencies): void {
     .alias('午夜电波')
     .action(wf.nightwaveCommand)
   ctx
-    .command('sortie', '当前突击')
+    .command('sortie', '每日突击')
     .alias('突击')
+    .alias('每日突击')
     .action(wf.sortieCommand)
   ctx
     .command('circuit', '本周回廊战甲及灵化之源')

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -120,6 +120,10 @@ export function setupCommands(ctx: Context, deps: PluginDependencies): void {
     .alias('午夜电波')
     .action(wf.nightwaveCommand)
   ctx
+    .command('sortie', '当前突击')
+    .alias('突击')
+    .action(wf.sortieCommand)
+  ctx
     .command('circuit', '本周回廊战甲及灵化之源')
     .alias('灵化之源')
     .alias('灵化')

--- a/src/commands/wf.ts
+++ b/src/commands/wf.ts
@@ -9,6 +9,7 @@ import {
   RelicComponent,
   RivenComponent,
   RivenStatComponent,
+  SortieComponent,
   VoidTraderComponent,
   WeeklyComponent,
   WeeklyRivenComponent,
@@ -25,6 +26,7 @@ import {
   getNightwave,
   getRailjackFissures,
   getRelic,
+  getSortie,
   getStaticRivenStats,
   getSteelPathFissures,
   getVoidTrader,
@@ -49,6 +51,7 @@ export function createWfCommands(deps: PluginDependencies): {
   ) => Promise<string>
   weeklyCommand: (_action: Argv) => Promise<string>
   nightwaveCommand: (_action: Argv) => Promise<string>
+  sortieCommand: (_action: Argv) => Promise<string>
   weeklyRivenCommand: (_action: Argv, minPrice?: number) => Promise<string>
   environmentCommand: () => Promise<string>
   bountyCetusCommand: () => Promise<string>
@@ -203,6 +206,15 @@ export function createWfCommands(deps: PluginDependencies): {
       }
 
       return render(NightwaveComponent(result.data))
+    },
+
+    sortieCommand: async (_action: Argv) => {
+      const result = await getSortie()
+      if (!result.ok) {
+        return t(result)
+      }
+
+      return render(SortieComponent(result.data))
     },
 
     weeklyRivenCommand: async (_action: Argv, minPrice?: number) => {

--- a/src/components/wf.tsx
+++ b/src/components/wf.tsx
@@ -13,6 +13,7 @@ import type {
   RivenAttributeUnit,
   RivenStatAnalyzeResult,
   RivenStatResult,
+  Sortie,
   VoidTrader,
 } from '../warframe'
 import { hexToRgb, lerp, rgbToHex } from '../utils'
@@ -919,6 +920,83 @@ export function NightwaveComponent(board: NightwaveBoard): Element {
           </div>
         ))}
       </div>
+    </div>
+  )
+}
+
+export function SortieComponent(sortie: Sortie): Element {
+  const timeLeft = sortie.expiry - Date.now()
+  const timeColor
+    = timeLeft > 3600000
+      ? 'var(--wf-success)'
+      : timeLeft > 600000
+        ? 'var(--wf-info)'
+        : 'var(--wf-danger)'
+  const sectionStyle = `
+    border-radius: var(--wf-radius);
+    border: 1px solid var(--wf-border);
+    padding: 12px 14px;
+    background-color: var(--wf-bg-subtle);
+    box-shadow: var(--wf-shadow-inner);
+    color: var(--wf-text-body);
+  `
+  const missionCardStyle = `
+    border-radius: var(--wf-radius-md);
+    border: 1px solid var(--wf-border);
+    padding: 8px 10px;
+    margin-bottom: 8px;
+    background-color: var(--wf-bg-card);
+  `
+
+  return (
+    <div
+      style="width:320px;background-color:var(--wf-bg-card);border-radius:var(--wf-radius);padding:10px;box-shadow:var(--wf-shadow-card);border:1px solid var(--wf-border);font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;color:var(--wf-text-body);"
+    >
+      <section style={sectionStyle}>
+        <div style="font-size:16px;font-weight:600;color:var(--wf-text-primary);margin-bottom:8px;">
+          {`${sortie.modeName}: ${sortie.boss}${sortie.faction ? ` (${sortie.faction})` : ''}`}
+        </div>
+        <div
+          style={`font-size:13px;margin-bottom:8px;color:${timeColor};`}
+        >
+          剩余
+          {sortie.remaining}
+        </div>
+        {sortie.missions.map((mission) => {
+          const location = [mission.node.system, mission.node.name]
+            .filter(Boolean)
+            .join(' · ')
+          const levels = mission.node.minLevel && mission.node.maxLevel
+            ? `Lv.${mission.node.minLevel}-${mission.node.maxLevel}`
+            : ''
+          const mapAndLevel = [location, levels].filter(Boolean).join(' · ')
+
+          return (
+            <div style={missionCardStyle}>
+              <div style="font-size:13px;font-weight:600;margin-bottom:4px;color:var(--wf-text-body);">
+                {mission.type}
+              </div>
+              {mapAndLevel
+                ? (
+                    <div style="font-size:12px;color:var(--wf-text-secondary);">
+                      {mapAndLevel}
+                    </div>
+                  )
+                : null}
+              {mission.modifier
+                ? (
+                    <div style="font-size:12px;color:var(--wf-text-secondary);">
+                      <span style="font-weight:600;margin-right:4px;color:var(--wf-text-body);">
+                        条件:
+                      </span>
+                      {mission.modifier}
+                    </div>
+                  )
+                : null}
+            </div>
+          )
+        })}
+      </section>
     </div>
   )
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -12,6 +12,8 @@ export const messages = {
   'bounty.unavailable': '当前该地点暂无可用赏金',
   'nightwave.unavailable': '当前没有午夜电波',
 
+  'sortie.unavailable': '当前没有突击',
+
   'voidTrader.drifting': '虚空商人仍在未知地带漂流...',
   'voidTrader.arriving': '距离虚空商人到达还有: {time}',
 

--- a/src/warframe/data/wf/globalWorldState.ts
+++ b/src/warframe/data/wf/globalWorldState.ts
@@ -4,6 +4,7 @@ import type { Fissure, RawSeasonInfo, RawSyndicateMission } from '../../types'
 import { dict_zh, ExportRegions } from 'warframe-public-export-plus'
 import {
   extractSeasonInfoRaw,
+  extractSortieRaw,
   extractSyndicateMissionsRaw,
   fetchWorldStateJson,
   getWorldState,
@@ -50,6 +51,7 @@ export const globalWorldState = createAsyncCache(async () => {
 
   const syndicateMissionsRaw: RawSyndicateMission[] = extractSyndicateMissionsRaw(json)
   const seasonInfoRaw: RawSeasonInfo | undefined = extractSeasonInfoRaw(json)
+  const sortieRaw = extractSortieRaw(json)
   const worldState = await getWorldState(json)
   const fissures: Fissure[] = []
   const rjFissures: Fissure[] = []
@@ -75,6 +77,7 @@ export const globalWorldState = createAsyncCache(async () => {
     raw: worldState,
     syndicateMissionsRaw,
     seasonInfoRaw,
+    sortieRaw,
     fissures,
     spFissures,
     rjFissures,

--- a/src/warframe/data/wf/sortie.ts
+++ b/src/warframe/data/wf/sortie.ts
@@ -1,0 +1,19 @@
+import { dict_zh } from 'warframe-public-export-plus'
+import { dictZhExtra } from '../../assets/index'
+
+const MODE_NAME_KEY = '/Lotus/Language/Menu/SortieMissionName'
+
+/** WARFRAME Wiki Sortie mechanics: 50–60 / 65–80 / 80–100 by mission index. */
+const SORTIE_ENEMY_LEVELS: Array<{ minLevel: number, maxLevel: number }> = [
+  { minLevel: 50, maxLevel: 60 },
+  { minLevel: 65, maxLevel: 80 },
+  { minLevel: 80, maxLevel: 100 },
+]
+
+export function getSortieModeName(): string {
+  return dict_zh[MODE_NAME_KEY] ?? dictZhExtra[MODE_NAME_KEY] ?? MODE_NAME_KEY
+}
+
+export function getSortieEnemyLevels(index: number): { minLevel: number, maxLevel: number } {
+  return SORTIE_ENEMY_LEVELS[index] ?? SORTIE_ENEMY_LEVELS[SORTIE_ENEMY_LEVELS.length - 1]
+}

--- a/src/warframe/infrastructure/wf/wf-api.ts
+++ b/src/warframe/infrastructure/wf/wf-api.ts
@@ -1,5 +1,5 @@
 import type WorldState from 'warframe-worldstate-parser'
-import type { OracleBountyCycle, RawSeasonInfo, RawSyndicateMission } from '../../types'
+import type { OracleBountyCycle, RawSeasonInfo, RawSortie, RawSyndicateMission } from '../../types'
 
 import { Baro } from '../../assets/index'
 import { fetchAsyncData, fetchAsyncText } from '../../utils'
@@ -28,6 +28,18 @@ export function extractSeasonInfoRaw(json: string): RawSeasonInfo | undefined {
       ...info,
       ActiveChallenges: Array.isArray(info.ActiveChallenges) ? info.ActiveChallenges : [],
     }
+  }
+  catch {
+    return undefined
+  }
+}
+
+export function extractSortieRaw(json: string): RawSortie | undefined {
+  try {
+    const data = JSON.parse(json) as { Sorties?: RawSortie[] }
+    return Array.isArray(data.Sorties) && data.Sorties.length > 0
+      ? data.Sorties[0]
+      : undefined
   }
   catch {
     return undefined

--- a/src/warframe/infrastructure/wf/wfcd-adapter.ts
+++ b/src/warframe/infrastructure/wf/wfcd-adapter.ts
@@ -68,6 +68,21 @@ export function fissureTierNumToNumber(a: number | string): number {
   return typeof a === 'string' ? Number(a.charAt(5)) : a
 }
 
+export async function translateSortieBoss(key: string): Promise<string> {
+  const { sortieBoss } = await import('warframe-worldstate-data/utilities')
+  return sortieBoss(key, 'zh')
+}
+
+export async function translateSortieFaction(key: string): Promise<string> {
+  const { sortieFaction } = await import('warframe-worldstate-data/utilities')
+  return sortieFaction(key, 'zh')
+}
+
+export async function translateSortieModifier(key: string): Promise<string> {
+  const { sortieModifier } = await import('warframe-worldstate-data/utilities')
+  return sortieModifier(key, 'zh')
+}
+
 export function getVoidTraderItem(i: {
   item: string
   uniqueName: string

--- a/src/warframe/services/wf-service.ts
+++ b/src/warframe/services/wf-service.ts
@@ -13,6 +13,7 @@ import type {
   NightwaveBoard,
   OcrAPISecret,
   RawSeasonInfo,
+  RawSortie,
   Relic,
   RivenAttribute,
   RivenStatAnalyzeResult,
@@ -20,6 +21,8 @@ import type {
   RivenStatCountType,
   RivenStatResult,
   RivenWeaponType,
+  Sortie,
+  SortieMission,
   VoidTrader,
   WarframeResult,
 } from '../types'
@@ -48,6 +51,10 @@ import { relics } from '../data/wf/relics'
 import { rivenAttrValueDict } from '../data/wf/rivenBaseValues'
 import { weaponRivenDispositionDict } from '../data/wf/rivenDisposition'
 import { rivenStatFixFactor } from '../data/wf/rivenStatData'
+import {
+  getSortieEnemyLevels,
+  getSortieModeName,
+} from '../data/wf/sortie'
 import { globalRivenAttribute } from '../data/wfm/globalRivenAttribute'
 import { globalRivenItemData } from '../data/wfm/globalRivenItem'
 import { extractTextFromImage } from '../infrastructure/ocr-api'
@@ -63,6 +70,9 @@ import {
   getMissionTypeKey,
   getSolNodeKey,
   getVoidTraderItem,
+  translateSortieBoss,
+  translateSortieFaction,
+  translateSortieModifier,
 } from '../infrastructure/wf/wfcd-adapter'
 import { failure } from '../types/warframe-result'
 import {
@@ -212,6 +222,100 @@ export async function adaptArchonHunt(source: {
     modeName: getArchonHuntModeName(),
     name,
     missions,
+  }
+}
+
+function mongoDateMs(value?: { $date?: { $numberLong?: string } }): number | undefined {
+  const raw = value?.$date?.$numberLong
+  if (!raw) {
+    return undefined
+  }
+  const ms = Number(raw)
+  return Number.isFinite(ms) ? ms : undefined
+}
+
+export async function adaptSortie(
+  source: RawSortie,
+  dates?: { activation?: Date, expiry?: Date },
+): Promise<Sortie> {
+  const expiryMs = dates?.expiry?.getTime() ?? mongoDateMs(source.Expiry) ?? 0
+  const missions = await Promise.all(
+    (source.Variants ?? []).map(async (variant, index): Promise<SortieMission> => {
+      const missionType = variant.missionType ?? ''
+      const receivedType = (await getMissionTypeKey(missionType)) || missionType
+      const type = dict_zh[ExportMissionTypes[receivedType]?.name ?? ''] ?? missionType
+      const nodeId = variant.node ?? ''
+      const solNodeKey = (await getSolNodeKey(nodeId)) || nodeId
+      const region = solNodeKey ? ExportRegions[solNodeKey] : undefined
+      const levels = getSortieEnemyLevels(index)
+      const node = region
+        ? {
+            ...regionToShort(region, dict_zh),
+            minLevel: levels.minLevel,
+            maxLevel: levels.maxLevel,
+          }
+        : {
+            name: nodeId,
+            system: '',
+            type: '',
+            faction: '',
+            minLevel: levels.minLevel,
+            maxLevel: levels.maxLevel,
+          }
+
+      return {
+        type,
+        node,
+        modifier: await translateSortieModifier(variant.modifierType ?? ''),
+      }
+    }),
+  )
+
+  const bossKey = source.Boss ?? ''
+  return {
+    modeName: getSortieModeName(),
+    boss: await translateSortieBoss(bossKey),
+    faction: await translateSortieFaction(bossKey),
+    expiry: expiryMs,
+    remaining: msToHumanReadable(expiryMs - Date.now()),
+    missions,
+  }
+}
+
+export async function getSortieFrom(snapshot?: {
+  raw?: { sortie?: { activation?: Date, expiry?: Date } }
+  sortieRaw?: RawSortie
+}): Promise<WarframeResult<Sortie>> {
+  if (!snapshot?.raw) {
+    return failure('common.fetchFailed', true)
+  }
+
+  const raw = snapshot.sortieRaw
+  if (!raw) {
+    return failure('sortie.unavailable')
+  }
+
+  const parsed = snapshot.raw.sortie
+  const expiryMs = parsed?.expiry?.getTime() ?? mongoDateMs(raw.Expiry)
+  if (expiryMs === undefined || expiryMs <= Date.now()) {
+    return failure('sortie.unavailable')
+  }
+
+  return {
+    ok: true,
+    data: await adaptSortie(raw, {
+      activation: parsed?.activation,
+      expiry: parsed?.expiry,
+    }),
+  }
+}
+
+export async function getSortie(): Promise<WarframeResult<Sortie>> {
+  try {
+    return await getSortieFrom(await globalWorldState.get())
+  }
+  catch {
+    return failure('common.fetchFailed', true)
   }
 }
 

--- a/src/warframe/types/index.ts
+++ b/src/warframe/types/index.ts
@@ -57,6 +57,12 @@ export type {
   RivenWeaponDisposition,
   RivenWeaponType,
 } from './wf/riven'
+export type {
+  RawSortie,
+  RawSortieVariant,
+  Sortie,
+  SortieMission,
+} from './wf/sortie'
 export type { VoidTrader, VoidTraderItem } from './wf/voidtrader'
 export type {
   ArchiMedea,

--- a/src/warframe/types/warframe-result.ts
+++ b/src/warframe/types/warframe-result.ts
@@ -6,6 +6,7 @@ export const warframeErrorCodes = [
   'arbitration.invalidDayRange',
   'bounty.unavailable',
   'nightwave.unavailable',
+  'sortie.unavailable',
   'voidTrader.drifting',
   'voidTrader.arriving',
   'riven.imageFetchFailed',

--- a/src/warframe/types/wf/sortie.ts
+++ b/src/warframe/types/wf/sortie.ts
@@ -1,0 +1,29 @@
+import type { WFRegionShort } from './region'
+
+export interface RawSortieVariant {
+  missionType?: string
+  modifierType?: string
+  node?: string
+}
+
+export interface RawSortie {
+  Boss?: string
+  Variants?: RawSortieVariant[]
+  Activation?: { $date?: { $numberLong?: string } }
+  Expiry?: { $date?: { $numberLong?: string } }
+}
+
+export interface SortieMission {
+  type: string
+  node: WFRegionShort
+  modifier: string
+}
+
+export interface Sortie {
+  modeName: string
+  boss: string
+  faction: string
+  expiry: number
+  remaining: string
+  missions: SortieMission[]
+}

--- a/tests/components/sortie.wf.spec.ts
+++ b/tests/components/sortie.wf.spec.ts
@@ -1,0 +1,61 @@
+import type { Sortie } from '../../src/warframe'
+import { expect } from 'chai'
+import { SortieComponent } from '../../src/components/wf'
+
+function mission(
+  type: string,
+  modifier: string,
+  minLevel: number,
+  maxLevel: number,
+): Sortie['missions'][number] {
+  return {
+    type,
+    modifier,
+    node: {
+      name: 'Metis',
+      system: '木星',
+      type: '救援',
+      faction: 'Corpus',
+      minLevel,
+      maxLevel,
+    },
+  }
+}
+
+describe('sortieComponent tests', () => {
+  it('renders title, boss, faction, remaining time, and mission cards', () => {
+    const data: Sortie = {
+      modeName: '突击',
+      boss: 'Alad V',
+      faction: 'Corpus',
+      expiry: Date.now() + 3_600_000,
+      remaining: '1小时0秒',
+      missions: [
+        mission('破坏', '辐射灾害', 50, 60),
+        mission('移动防御', '卓越者大本营', 65, 80),
+        mission('救援', '突击步枪 限定', 80, 100),
+      ],
+    }
+
+    const html = String(SortieComponent(data))
+
+    expect(html).to.include('突击: Alad V (Corpus)')
+    expect(html).to.include('剩余')
+    expect(html).to.include('1小时0秒')
+    expect(html).to.include('破坏')
+    expect(html).to.include('移动防御')
+    expect(html).to.include('救援')
+    expect(html).to.include('width:320px')
+    expect(html).to.include('木星 · Metis · Lv.50-60')
+    expect(html).to.include('Lv.65-80')
+    expect(html).to.include('Lv.80-100')
+    expect(html).to.include('辐射灾害')
+    expect(html).to.include('卓越者大本营')
+    expect(html).to.include('突击步枪 限定')
+    expect(html).to.include('条件')
+    expect(html).to.not.match(/<div[^>]*\/>/)
+    expect(html).to.not.include('戰甲的能量上限降低為四分之一')
+    expect(html).to.not.include('救援 ·')
+    expect(html).to.not.include('木星 · Metis · Corpus')
+  })
+})

--- a/tests/services/wf/sortie.wf.spec.ts
+++ b/tests/services/wf/sortie.wf.spec.ts
@@ -1,0 +1,197 @@
+import type { RawSortie } from '../../../src/warframe/types/wf/sortie'
+import { expect } from 'chai'
+import { dict_zh } from 'warframe-public-export-plus'
+import { t } from '../../../src/i18n'
+import { dictZhExtra } from '../../../src/warframe/assets'
+import { extractSortieRaw } from '../../../src/warframe/infrastructure/wf/wf-api'
+import { adaptSortie, getSortieFrom } from '../../../src/warframe/services'
+
+function translateLotus(key: string): string | undefined {
+  return dict_zh[key] ?? dictZhExtra[key]
+}
+
+function futureExpiry(ms = 3_600_000): Date {
+  return new Date(Date.now() + ms)
+}
+
+function rawSortie(overrides: Partial<RawSortie> = {}): RawSortie {
+  return {
+    Boss: 'SORTIE_BOSS_ALAD',
+    Activation: { $date: { $numberLong: String(Date.now() - 3_600_000) } },
+    Expiry: { $date: { $numberLong: String(Date.now() + 3_600_000) } },
+    Variants: [
+      {
+        missionType: 'MT_SABOTAGE',
+        modifierType: 'SORTIE_MODIFIER_HAZARD_RADIATION',
+        node: 'SolNode126',
+      },
+      {
+        missionType: 'MT_MOBILE_DEFENSE',
+        modifierType: 'SORTIE_MODIFIER_EXIMUS',
+        node: 'SolNode66',
+      },
+      {
+        missionType: 'MT_RESCUE',
+        modifierType: 'SORTIE_MODIFIER_RIFLE_ONLY',
+        node: 'SolNode216',
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function snapshot(
+  sortieRaw: RawSortie | undefined,
+  expiry = futureExpiry(),
+) {
+  return {
+    raw: {
+      sortie: { expiry, activation: new Date() },
+    },
+    sortieRaw,
+  }
+}
+
+describe('adaptSortie Tests', () => {
+  it('translates the boss, faction, mode name, and three missions in order', async () => {
+    const result = await adaptSortie(rawSortie())
+
+    expect(result.modeName).to.equal(
+      translateLotus('/Lotus/Language/Menu/SortieMissionName'),
+    )
+    expect(result.boss).to.equal('Alad V')
+    expect(result.faction).to.equal('Corpus')
+    expect(result.missions).to.have.length(3)
+    expect(result.missions.map(mission => mission.type)).to.deep.equal([
+      '破坏',
+      '移动防御',
+      '救援',
+    ])
+    expect(result.missions.map(mission => mission.node.name)).to.deep.equal([
+      'Metis',
+      'Unda',
+      'Valefor',
+    ])
+    expect(result.missions.map(mission => mission.node.system)).to.deep.equal([
+      '木星',
+      '金星',
+      '欧罗巴',
+    ])
+    expect(result.missions.map(mission => mission.modifier)).to.deep.equal([
+      '辐射灾害',
+      '卓越者大本营',
+      '突击步枪 限定',
+    ])
+  })
+
+  it('uses sortie enemy levels by mission index instead of star-chart levels', async () => {
+    const result = await adaptSortie(rawSortie())
+
+    expect(result.missions[0].node.minLevel).to.equal(50)
+    expect(result.missions[0].node.maxLevel).to.equal(60)
+    expect(result.missions[1].node.minLevel).to.equal(65)
+    expect(result.missions[1].node.maxLevel).to.equal(80)
+    expect(result.missions[2].node.minLevel).to.equal(80)
+    expect(result.missions[2].node.maxLevel).to.equal(100)
+  })
+
+  it('falls back to the raw node key when the sol node cannot be resolved', async () => {
+    const result = await adaptSortie(rawSortie({
+      Variants: [
+        {
+          missionType: 'MT_EXTERMINATION',
+          modifierType: 'SORTIE_MODIFIER_LOW_ENERGY',
+          node: 'NotARealNode',
+        },
+      ],
+    }))
+
+    expect(result.missions[0].type).to.equal('歼灭')
+    expect(result.missions[0].node.name).to.equal('NotARealNode')
+    expect(result.missions[0].node.system).to.equal('')
+    expect(result.missions[0].modifier).to.equal('能量减少')
+  })
+
+  it('falls back to the raw modifier key when it cannot be translated', async () => {
+    const result = await adaptSortie(rawSortie({
+      Variants: [
+        {
+          missionType: 'MT_SABOTAGE',
+          modifierType: 'SORTIE_MODIFIER_NOT_REAL',
+          node: 'SolNode126',
+        },
+      ],
+    }))
+
+    expect(result.missions[0].modifier).to.equal('SORTIE_MODIFIER_NOT_REAL')
+  })
+})
+
+describe('getSortie Tests', () => {
+  it('returns adapted sortie data from the worldstate snapshot', async () => {
+    const expiry = futureExpiry()
+    const result = await getSortieFrom(snapshot(rawSortie(), expiry))
+    expect(result.ok).to.equal(true)
+    if (!result.ok) {
+      return
+    }
+
+    expect(result.data.boss).to.equal('Alad V')
+    expect(result.data.missions).to.have.length(3)
+    expect(result.data.missions[0].type).to.equal('破坏')
+    expect(result.data.expiry).to.equal(expiry.getTime())
+    expect(result.data.remaining).to.match(/小时|分钟|秒/)
+  })
+
+  it('fails when Sorties are missing', async () => {
+    const result = await getSortieFrom(snapshot(undefined))
+    expect(result.ok).to.equal(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).to.equal('sortie.unavailable')
+    expect(t(result)).to.equal('当前没有突击')
+  })
+
+  it('fails when the sortie has expired', async () => {
+    const expiry = new Date(Date.now() - 1_000)
+    const result = await getSortieFrom(snapshot(rawSortie({
+      Expiry: { $date: { $numberLong: String(expiry.getTime()) } },
+    }), expiry))
+    expect(result.ok).to.equal(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).to.equal('sortie.unavailable')
+  })
+
+  it('fails with common.fetchFailed when worldstate cannot be loaded', async () => {
+    const result = await getSortieFrom()
+    expect(result.ok).to.equal(false)
+    if (result.ok) {
+      return
+    }
+
+    expect(result.error.code).to.equal('common.fetchFailed')
+    expect(result.error.retryable).to.equal(true)
+  })
+})
+
+describe('extractSortieRaw', () => {
+  it('returns Sorties[0] from worldstate json', () => {
+    const raw = extractSortieRaw(JSON.stringify({
+      Sorties: [{ Boss: 'SORTIE_BOSS_VOR', Variants: [] }],
+      LiteSorties: [{ Boss: 'SORTIE_BOSS_BOREAL' }],
+    }))
+
+    expect(raw?.Boss).to.equal('SORTIE_BOSS_VOR')
+    expect(raw?.Variants).to.deep.equal([])
+  })
+
+  it('returns undefined when Sorties are empty', () => {
+    expect(extractSortieRaw(JSON.stringify({ Sorties: [] }))).to.equal(undefined)
+    expect(extractSortieRaw('{')).to.equal(undefined)
+  })
+})


### PR DESCRIPTION
Surface current Sorties as a Puppeteer image so players can query 突击/sortie without using Archon Hunt or LiteSorties.