### PR TITLE
feat(wf): add alert command

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -35,6 +35,10 @@ export function setupCommands(ctx: Context, deps: PluginDependencies): void {
     .alias('入侵')
     .action(wf.invasionCommand)
   ctx
+    .command('alert', '当前警报')
+    .alias('警报')
+    .action(wf.alertCommand)
+  ctx
     .command('fissure-sp', '当前钢铁之路虚空裂隙')
     .alias('spfissure')
     .alias('钢铁裂缝')

--- a/src/commands/wf.ts
+++ b/src/commands/wf.ts
@@ -1,6 +1,7 @@
 import type { Argv, Dict } from 'koishi'
 import type { PluginDependencies } from '../types/config'
 import {
+  AlertComponent,
   ArbitrationComponent,
   BountyComponent,
   CircuitComponent,
@@ -18,6 +19,7 @@ import {
 import { t } from '../i18n'
 import {
   applyRelicData,
+  getAlerts,
   getAnalyzedRiven,
   getArbitrations,
   getBounty,
@@ -42,6 +44,7 @@ export function createWfCommands(deps: PluginDependencies): {
   voidtraderCommand: (_action: Argv) => Promise<string>
   fissureCommand: (_action: Argv) => Promise<string>
   invasionCommand: (_action: Argv) => Promise<string>
+  alertCommand: (_action: Argv) => Promise<string>
   steelPathFissureCommand: (_action: Argv) => Promise<string>
   railjackFissureCommand: (_action: Argv) => Promise<string>
   relicCommand: (_action: Argv, input: string) => Promise<string>
@@ -123,6 +126,15 @@ export function createWfCommands(deps: PluginDependencies): {
       }
 
       return render(InvasionComponent(result.data))
+    },
+
+    alertCommand: async (_action: Argv) => {
+      const result = await getAlerts()
+      if (!result.ok) {
+        return t(result)
+      }
+
+      return render(AlertComponent(result.data))
     },
 
     steelPathFissureCommand: async (_action: Argv) => {

--- a/src/components/wf.tsx
+++ b/src/components/wf.tsx
@@ -1,6 +1,7 @@
 import type { Element } from 'koishi'
 import type { WeeklyRiven } from 'warframe-weekly-rivens'
 import type {
+  AlertBoard,
   Arbitration,
   ArchiMedea,
   ArchonHunt,
@@ -1982,6 +1983,84 @@ export function VoidTraderComponent(data: VoidTrader): Element {
           ))}
         </tbody>
       </table>
+    </div>
+  )
+}
+
+export function AlertComponent(board: AlertBoard): Element {
+  const missionCardStyle = `
+    border-radius: var(--wf-radius-md);
+    border: 1px solid var(--wf-border);
+    padding: 8px 10px;
+    margin-bottom: 8px;
+    background-color: var(--wf-bg-card);
+  `
+
+  return (
+    <div
+      style="width:360px;background-color:var(--wf-bg-card);border-radius:var(--wf-radius);padding:10px;box-shadow:var(--wf-shadow-card);border:1px solid var(--wf-border);font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif;color:var(--wf-text-body);"
+    >
+      <h1 style="font-size:18px;font-weight:bold;color:var(--wf-text-primary);margin:0 0 8px 0;text-align:center;">
+        {board.title}
+      </h1>
+      {board.alerts.map((entry) => {
+        const location = [entry.node.system, entry.node.name, entry.node.faction]
+          .filter(Boolean)
+          .join(' · ')
+        const levels = entry.node.minLevel && entry.node.maxLevel
+          ? `Lv.${entry.node.minLevel}-${entry.node.maxLevel}`
+          : ''
+        const rewardText = entry.rewards
+          .map(reward => reward.count > 1 ? `${reward.count}×${reward.name}` : reward.name)
+          .join(' · ')
+        const timeLeft = entry.expiry - Date.now()
+        const timeColor
+          = timeLeft > 3600000
+            ? 'var(--wf-success)'
+            : timeLeft > 600000
+              ? 'var(--wf-info)'
+              : 'var(--wf-danger)'
+
+        return (
+          <div style={missionCardStyle}>
+            <div style="font-size:13px;font-weight:600;margin-bottom:4px;color:var(--wf-text-body);">
+              {entry.type}
+              {entry.nightmare
+                ? (
+                    <span style="margin-left:8px;font-size:12px;color:var(--wf-accent);">
+                      {entry.nightmare}
+                    </span>
+                  )
+                : null}
+            </div>
+            {location
+              ? (
+                  <div style="font-size:12px;color:var(--wf-text-secondary);">
+                    {location}
+                  </div>
+                )
+              : null}
+            {levels
+              ? (
+                  <div style="font-size:12px;color:var(--wf-text-secondary);">
+                    {levels}
+                  </div>
+                )
+              : null}
+            {rewardText
+              ? (
+                  <div style="font-size:12px;color:var(--wf-text-secondary);">
+                    {rewardText}
+                  </div>
+                )
+              : null}
+            <div style={`font-size:12px;color:${timeColor};`}>
+              剩余
+              {entry.remaining}
+            </div>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -11,6 +11,7 @@ export const messages = {
 
   'bounty.unavailable': '当前该地点暂无可用赏金',
   'invasion.unavailable': '当前没有入侵',
+  'alert.unavailable': '当前没有警报',
   'nightwave.unavailable': '当前没有午夜电波',
 
   'sortie.unavailable': '当前没有突击',

--- a/src/warframe/services/wf-service.ts
+++ b/src/warframe/services/wf-service.ts
@@ -2,6 +2,8 @@ import type { TFaction } from 'warframe-public-export-plus'
 import type { WeeklyRiven } from 'warframe-weekly-rivens'
 
 import type {
+  AlertBoard,
+  AlertInfo,
   Arbitration,
   ArchiMedea,
   ArchiMedeaDebuff,
@@ -711,6 +713,119 @@ export async function getInvasionsFrom(snapshot?: {
 export async function getInvasions(): Promise<WarframeResult<InvasionBoard>> {
   try {
     return await getInvasionsFrom(await globalWorldState.get())
+  }
+  catch {
+    return failure('common.fetchFailed', true)
+  }
+}
+
+const ALERT_TITLE_KEY = '/Lotus/Language/Menu/AlertPopup_Alert'
+const ALERT_NIGHTMARE_KEY = '/Lotus/Language/Menu/NightmareModeName'
+
+export async function adaptAlerts(
+  alerts: readonly {
+    expiry?: Date
+    mission?: {
+      nodeKey?: string
+      typeKey?: string
+      minEnemyLevel?: number
+      maxEnemyLevel?: number
+      nightmare?: boolean
+      reward?: {
+        items?: string[]
+        countedItems?: Array<{ type?: string, key?: string, count?: number }>
+        credits?: number
+      }
+    }
+  }[] = [],
+  now: number = Date.now(),
+): Promise<AlertBoard> {
+  const adapted: AlertInfo[] = []
+  for (const raw of alerts) {
+    const expiry = raw.expiry?.getTime() ?? 0
+    if (expiry <= now) {
+      continue
+    }
+
+    const mission = raw.mission ?? {}
+    const typeKey = mission.typeKey ?? ''
+    const receivedType = await getMissionTypeKey(typeKey)
+    const nodeKey = mission.nodeKey ?? ''
+    const solNodeKey = await getSolNodeKey(nodeKey)
+    const region = solNodeKey ? ExportRegions[solNodeKey] : undefined
+    const short = region
+      ? regionToShort(region, dict_zh)
+      : {
+          name: nodeKey,
+          system: '',
+          type: '',
+          faction: '',
+          minLevel: 0,
+          maxLevel: 0,
+        }
+
+    const reward = mission.reward
+    const rewards: AlertInfo['rewards'] = []
+    for (const item of reward?.items ?? []) {
+      rewards.push({
+        name: item.startsWith('/Lotus') ? resolveExportItemNameZh(item) : item,
+        count: 1,
+      })
+    }
+    for (const item of reward?.countedItems ?? []) {
+      const source = item.key ?? item.type ?? ''
+      if (!source) {
+        continue
+      }
+      rewards.push({
+        name: source.startsWith('/Lotus') ? resolveExportItemNameZh(source) : source,
+        count: item.count ?? 1,
+      })
+    }
+    if (reward?.credits && reward.credits > 0) {
+      rewards.push({
+        name: resolveExportItemNameZh(`/${reward.credits}Credits`),
+        count: 1,
+      })
+    }
+
+    const nightmare = mission.nightmare
+      ? dict_zh[ALERT_NIGHTMARE_KEY] ?? dictZhExtra[ALERT_NIGHTMARE_KEY]
+      : undefined
+
+    adapted.push({
+      type: dict_zh[ExportMissionTypes[receivedType]?.name ?? ''] ?? typeKey,
+      node: {
+        ...short,
+        minLevel: mission.minEnemyLevel ?? 0,
+        maxLevel: mission.maxEnemyLevel ?? 0,
+      },
+      rewards,
+      remaining: msToHumanReadable(expiry - now),
+      expiry,
+      ...(nightmare ? { nightmare } : {}),
+    })
+  }
+
+  return {
+    title: dict_zh[ALERT_TITLE_KEY] ?? dictZhExtra[ALERT_TITLE_KEY] ?? ALERT_TITLE_KEY,
+    alerts: adapted,
+  }
+}
+
+export async function getAlerts(): Promise<WarframeResult<AlertBoard>> {
+  try {
+    const { raw } = await globalWorldState.get()
+    if (!raw) {
+      return failure('common.fetchFailed', true)
+    }
+
+    const data = await adaptAlerts(raw.alerts ?? [])
+    if (data.alerts.length === 0) {
+      return failure('alert.unavailable')
+    }
+
+    return { ok: true, data }
   }
   catch {
     return failure('common.fetchFailed', true)

--- a/src/warframe/types/index.ts
+++ b/src/warframe/types/index.ts
@@ -13,6 +13,7 @@ export type {
   WarframeFailure,
   WarframeResult,
 } from './warframe-result'
+export type { AlertBoard, AlertInfo, AlertReward } from './wf/alert'
 export type { Arbitration, ArbitrationShort } from './wf/arbitration'
 export type {
   BountyBoard,

--- a/src/warframe/types/warframe-result.ts
+++ b/src/warframe/types/warframe-result.ts
@@ -6,6 +6,7 @@ export const warframeErrorCodes = [
   'arbitration.invalidDayRange',
   'bounty.unavailable',
   'invasion.unavailable',
+  'alert.unavailable',
   'nightwave.unavailable',
   'sortie.unavailable',
   'voidTrader.drifting',

--- a/src/warframe/types/wf/alert.ts
+++ b/src/warframe/types/wf/alert.ts
@@ -1,0 +1,20 @@
+import type { WFRegionShort } from './region'
+
+export interface AlertReward {
+  name: string
+  count: number
+}
+
+export interface AlertInfo {
+  type: string
+  node: WFRegionShort
+  rewards: AlertReward[]
+  remaining: string
+  expiry: number
+  nightmare?: string
+}
+
+export interface AlertBoard {
+  title: string
+  alerts: AlertInfo[]
+}

--- a/tests/components/alert.wf.spec.ts
+++ b/tests/components/alert.wf.spec.ts
@@ -1,0 +1,62 @@
+import type { AlertBoard, AlertInfo } from '../../src/warframe'
+import { expect } from 'chai'
+import { AlertComponent } from '../../src/components/wf'
+
+function alert(overrides: Partial<AlertInfo> = {}): AlertInfo {
+  return {
+    type: '拦截',
+    node: {
+      name: '乌戈塔',
+      system: '虚空',
+      type: '捕获',
+      faction: '奥罗金',
+      minLevel: 65,
+      maxLevel: 70,
+    },
+    rewards: [
+      { name: '电磁力场装置', count: 1 },
+      { name: '12200 现金', count: 1 },
+    ],
+    remaining: '1小时0秒',
+    expiry: Date.now() + 3_600_000,
+    ...overrides,
+  }
+}
+
+function board(overrides: Partial<AlertBoard> = {}): AlertBoard {
+  return {
+    title: '警报',
+    alerts: [alert()],
+    ...overrides,
+  }
+}
+
+describe('alertComponent tests', () => {
+  it('renders type, location, level, rewards, and remaining time', () => {
+    const html = String(AlertComponent(board()))
+
+    expect(html).to.include('警报')
+    expect(html).to.include('拦截')
+    expect(html).to.include('虚空 · 乌戈塔 · 奥罗金')
+    expect(html).to.include('Lv.65-70')
+    expect(html).to.include('电磁力场装置')
+    expect(html).to.include('12200 现金')
+    expect(html).to.include('剩余')
+    expect(html).to.include('1小时0秒')
+    expect(html).to.not.include('捕获')
+    expect(html).to.not.match(/<div[^>]*\/>/)
+  })
+
+  it('shows the mapped nightmare word and stacked counts without empty tags', () => {
+    const html = String(AlertComponent(board({
+      alerts: [alert({
+        nightmare: '噩梦',
+        rewards: [{ name: '电磁力场装置', count: 3 }],
+      })],
+    })))
+
+    expect(html).to.include('噩梦')
+    expect(html).to.include('3×电磁力场装置')
+    expect(html).to.not.match(/<div[^>]*\/>/)
+  })
+})

--- a/tests/services/wf/alert.wf.spec.ts
+++ b/tests/services/wf/alert.wf.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { dict_zh, ExportRegions } from 'warframe-public-export-plus'
 import { t } from '../../../src/i18n'
+import { dictZhExtra } from '../../../src/warframe/assets'
 import { resolveExportItemNameZh } from '../../../src/warframe/infrastructure/wf/bounty-adapter'
 import { adaptAlerts } from '../../../src/warframe/services'
 import { msToHumanReadable } from '../../../src/warframe/utils/time'
@@ -11,6 +12,12 @@ const HOUR = 3_600_000
 const LOTUS_REWARD = '/Lotus/Types/Items/Research/EnergyComponent'
 const TITLE_KEY = '/Lotus/Language/Menu/AlertPopup_Alert'
 const NIGHTMARE_KEY = '/Lotus/Language/Menu/NightmareModeName'
+
+function officialZh(key: string): string {
+  const text = dict_zh[key] ?? dictZhExtra[key]
+  expect(text, key).to.be.a('string').and.not.equal(key)
+  return text
+}
 
 function parsedAlert(overrides: Record<string, unknown> = {}) {
   return {
@@ -39,7 +46,7 @@ describe('adaptAlerts', () => {
   it('translates mission type and node into Chinese', async () => {
     const board = await adaptAlerts([parsedAlert()], NOW)
 
-    expect(board.title).to.equal(dict_zh[TITLE_KEY])
+    expect(board.title).to.equal(officialZh(TITLE_KEY))
     expect(board.alerts).to.have.length(1)
     expect(board.alerts[0].type).to.equal('拦截')
     expect(board.alerts[0].node.name).to.equal(dict_zh[ExportRegions.SolNode406.name])
@@ -109,7 +116,7 @@ describe('adaptAlerts', () => {
 
     expect(empty.alerts).to.deep.equal([])
     expect(expired.alerts).to.deep.equal([])
-    expect(empty.title).to.equal(dict_zh[TITLE_KEY])
+    expect(empty.title).to.equal(officialZh(TITLE_KEY))
     expect(t('alert.unavailable')).to.equal('当前没有警报')
   })
 
@@ -126,6 +133,6 @@ describe('adaptAlerts', () => {
     })], NOW)
 
     expect(board.alerts[0].type).to.equal('破坏')
-    expect(board.alerts[0].nightmare).to.equal(dict_zh[NIGHTMARE_KEY])
+    expect(board.alerts[0].nightmare).to.equal(officialZh(NIGHTMARE_KEY))
   })
 })

--- a/tests/services/wf/alert.wf.spec.ts
+++ b/tests/services/wf/alert.wf.spec.ts
@@ -1,0 +1,131 @@
+import { expect } from 'chai'
+import { dict_zh, ExportRegions } from 'warframe-public-export-plus'
+import { t } from '../../../src/i18n'
+import { resolveExportItemNameZh } from '../../../src/warframe/infrastructure/wf/bounty-adapter'
+import { adaptAlerts } from '../../../src/warframe/services'
+import { msToHumanReadable } from '../../../src/warframe/utils/time'
+
+const NOW = Date.parse('2026-08-25T09:00:00Z')
+const HOUR = 3_600_000
+
+const LOTUS_REWARD = '/Lotus/Types/Items/Research/EnergyComponent'
+const TITLE_KEY = '/Lotus/Language/Menu/AlertPopup_Alert'
+const NIGHTMARE_KEY = '/Lotus/Language/Menu/NightmareModeName'
+
+function parsedAlert(overrides: Record<string, unknown> = {}) {
+  return {
+    activation: new Date(NOW - HOUR),
+    expiry: new Date(NOW + HOUR),
+    tag: 'LotusGift',
+    mission: {
+      nodeKey: 'Ukko (Void)',
+      typeKey: 'Interception',
+      minEnemyLevel: 65,
+      maxEnemyLevel: 70,
+      factionKey: 'Orokin',
+      nightmare: false,
+      description: 'Gift from the Lotus',
+      reward: {
+        items: [LOTUS_REWARD],
+        countedItems: [{ type: 'Marks of Valiance', key: 'Marks of Valiance', count: 20 }],
+        credits: 12200,
+      },
+    },
+    ...overrides,
+  }
+}
+
+describe('adaptAlerts', () => {
+  it('translates mission type and node into Chinese', async () => {
+    const board = await adaptAlerts([parsedAlert()], NOW)
+
+    expect(board.title).to.equal(dict_zh[TITLE_KEY])
+    expect(board.alerts).to.have.length(1)
+    expect(board.alerts[0].type).to.equal('拦截')
+    expect(board.alerts[0].node.name).to.equal(dict_zh[ExportRegions.SolNode406.name])
+    expect(board.alerts[0].node.system).to.equal(dict_zh[ExportRegions.SolNode406.systemName])
+    expect(board.alerts[0].node.faction).to.equal('奥罗金')
+  })
+
+  it('uses mission enemy levels instead of star-chart defaults', async () => {
+    const board = await adaptAlerts([parsedAlert()], NOW)
+    const alert = board.alerts[0]
+
+    expect(ExportRegions.SolNode406.minEnemyLevel).to.equal(30)
+    expect(ExportRegions.SolNode406.maxEnemyLevel).to.equal(35)
+    expect(alert.node.minLevel).to.equal(65)
+    expect(alert.node.maxLevel).to.equal(70)
+  })
+
+  it('resolves /Lotus rewards through resolveExportItemNameZh', async () => {
+    const board = await adaptAlerts([parsedAlert({
+      mission: {
+        nodeKey: 'Ukko (Void)',
+        typeKey: 'Interception',
+        minEnemyLevel: 65,
+        maxEnemyLevel: 70,
+        reward: {
+          items: [LOTUS_REWARD],
+          countedItems: [{
+            type: 'Fieldron',
+            key: LOTUS_REWARD,
+            count: 3,
+          }],
+          credits: 0,
+        },
+      },
+    })], NOW)
+
+    expect(board.alerts[0].rewards).to.deep.equal([
+      { name: resolveExportItemNameZh(LOTUS_REWARD), count: 1 },
+      { name: resolveExportItemNameZh(LOTUS_REWARD), count: 3 },
+    ])
+  })
+
+  it('keeps English countedItems.key values that are not item paths', async () => {
+    const board = await adaptAlerts([parsedAlert()], NOW)
+    const names = board.alerts[0].rewards.map(reward => reward.name)
+
+    expect(names).to.include('Marks of Valiance')
+    expect(names).to.include(resolveExportItemNameZh('/12200Credits'))
+    expect(names).to.include(resolveExportItemNameZh(LOTUS_REWARD))
+  })
+
+  it('drops expired alerts', async () => {
+    const board = await adaptAlerts([
+      parsedAlert({ expiry: new Date(NOW) }),
+      parsedAlert({ expiry: new Date(NOW - 1000) }),
+      parsedAlert({ expiry: new Date(NOW + HOUR) }),
+    ], NOW)
+
+    expect(board.alerts).to.have.length(1)
+    expect(board.alerts[0].expiry).to.equal(NOW + HOUR)
+    expect(board.alerts[0].remaining).to.equal(msToHumanReadable(HOUR))
+  })
+
+  it('returns an empty list when nothing is active', async () => {
+    const empty = await adaptAlerts([], NOW)
+    const expired = await adaptAlerts([parsedAlert({ expiry: new Date(NOW - 1) })], NOW)
+
+    expect(empty.alerts).to.deep.equal([])
+    expect(expired.alerts).to.deep.equal([])
+    expect(empty.title).to.equal(dict_zh[TITLE_KEY])
+    expect(t('alert.unavailable')).to.equal('当前没有警报')
+  })
+
+  it('maps nightmare to the official Chinese label when present', async () => {
+    const board = await adaptAlerts([parsedAlert({
+      mission: {
+        nodeKey: 'Ukko (Void)',
+        typeKey: 'Sabotage',
+        minEnemyLevel: 20,
+        maxEnemyLevel: 25,
+        nightmare: true,
+        reward: { items: [], countedItems: [], credits: 0 },
+      },
+    })], NOW)
+
+    expect(board.alerts[0].type).to.equal('破坏')
+    expect(board.alerts[0].nightmare).to.equal(dict_zh[NIGHTMARE_KEY])
+  })
+})


### PR DESCRIPTION
## Summary
- Add `alert` / `警报` for the current unexpired alert list (type, location, level, rewards, remaining time).
- Adapt `raw.alerts` from the existing world-state parser in `wf-service` (no extra cache extract, no world-state push changes).
- Use official Chinese panel/mission/node labels; empty boards return `当前没有警报`.

## Test plan
- [ ] `yarn vitest run tests/services/wf/alert.wf.spec.ts tests/components/alert.wf.spec.ts`
- [ ] `yarn dtsc`
- [ ] Run `alert` / `警报` in Koishi after `yarn build` and a full restart
- [ ] Confirm location is `星系 · 节点 · 阵营` with mission levels, not star-chart defaults
- [ ] Confirm an empty board returns 当前没有警报


Made with [Cursor](https://cursor.com)